### PR TITLE
Publish EntraCP v23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for ~~AzureCP~~ EntraCP
 
+## Unreleased
+
+* Fixed issues causing logging to not be actually written in SharePoint logs
+* Added logging categories "Azure Identity" and "Graph Requests"
+* Improved the readability of the errors recorded in the log
+* Better verify the responses from Graph, to avoid generating more exceptions if an error already happened
+
 ## EntraCP v22.0.20230927.29 enhancements & bug-fixes - Published in September 27, 2023
 
 * Rename project AzureCP to EntraCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Improve the management of tenant credentials, including new helpers to renew the client secret of certificate using PowerShell
 * Improve page TroubleshootEntraCP.aspx
 * Add a mechanism to use custom settings instead of settings from the persisted objects
 * Fix issues causing logging to not be actually written in SharePoint logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Improveed page TroubleshootEntraCP.aspx
+* Added a mechanism to use custom settings instead of settings from the persisted objects
 * Fixed issues causing logging to not be actually written in SharePoint logs
 * Added logging categories "Azure Identity" and "Graph Requests"
 * Improved the readability of the errors recorded in the log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix a bug causing a hang on the web application, when using the check permissions feature to verify the permissions of a trusted user
+* SharePoint 2016: The new minimum build version required to run EntraCP is 16.0.4483.1001 - January 2017 cumulative update
 * Improve the management of tenant credentials, including new helpers to renew the client secret of certificate using PowerShell
 * Improve page TroubleshootEntraCP.aspx
 * Add a mechanism to use custom settings instead of settings from the persisted objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Fix a bug causing a hang on the web application, when using the check permissions feature to verify the permissions of a trusted user
 * Improve the management of tenant credentials, including new helpers to renew the client secret of certificate using PowerShell
 * Improve page TroubleshootEntraCP.aspx
 * Add a mechanism to use custom settings instead of settings from the persisted objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## Unreleased
 
-* Improveed page TroubleshootEntraCP.aspx
-* Added a mechanism to use custom settings instead of settings from the persisted objects
-* Fixed issues causing logging to not be actually written in SharePoint logs
-* Added logging categories "Azure Identity" and "Graph Requests"
-* Improved the readability of the errors recorded in the log
-* Better verify the responses from Graph, to avoid generating more exceptions if an error already happened
+* Improve page TroubleshootEntraCP.aspx
+* Add a mechanism to use custom settings instead of settings from the persisted objects
+* Fix issues causing logging to not be actually written in SharePoint logs
+* Add logging categories "Azure Identity" and "Graph Requests"
+* Improve the readability of the errors recorded in the log
+* Better verify the responses from Graph, to avoid causing additional exceptions if an error already happened
+* Bump dependencies
 
 ## EntraCP v22.0.20230927.29 enhancements & bug-fixes - Published in September 27, 2023
 

--- a/Yvand.EntraCP.Tests/CustomConfigTests.cs
+++ b/Yvand.EntraCP.Tests/CustomConfigTests.cs
@@ -1,11 +1,10 @@
 ﻿using Microsoft.SharePoint.Administration.Claims;
-using NUnit.Framework;
-using System.Diagnostics;
-using System;
-using System.Security.Claims;
-using Yvand;
-using Yvand.EntraClaimsProvider.Configuration;
 using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.Security.Claims;
+using Yvand.EntraClaimsProvider.Configuration;
 
 namespace Yvand.EntraClaimsProvider.Tests
 {

--- a/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
+++ b/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
@@ -69,7 +69,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
-      <Version>3.13.3</Version>
+      <Version>3.14.0</Version>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter">
       <Version>4.5.0</Version>

--- a/Yvand.EntraCP/Package/Package.package
+++ b/Yvand.EntraCP/Package/Package.package
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns:dm0="http://schemas.microsoft.com/VisualStudio/2008/DslTools/Core" dslVersion="1.0.0.0" Id="1db45b9b-2fff-4f07-992b-344dde907316" solutionId="dd03bdd7-0645-475e-a852-f180b8bc8191" resetWebServer="true" deploymentServerType="ApplicationServer" title="AzureCP Subscription Edition" description="AzureCP Subscription Edition" sharePointProductVersion="16.0" name="EntraCP" xmlns="http://schemas.microsoft.com/VisualStudio/2008/SharePointTools/PackageModel">
+<package xmlns:dm0="http://schemas.microsoft.com/VisualStudio/2008/DslTools/Core" dslVersion="1.0.0.0" Id="1db45b9b-2fff-4f07-992b-344dde907316" solutionId="dd03bdd7-0645-475e-a852-f180b8bc8191" resetWebServer="true" deploymentServerType="ApplicationServer" title="EntraCP Claims Provider" description="EntraCP Claims Provider" sharePointProductVersion="16.0" name="EntraCP" xmlns="http://schemas.microsoft.com/VisualStudio/2008/SharePointTools/PackageModel">
   <assemblies>
     <customAssembly location="Azure.Core.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Azure.Core.dll" />
     <customAssembly location="Azure.Identity.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Azure.Identity.dll" />

--- a/Yvand.EntraCP/Package/Package.package
+++ b/Yvand.EntraCP/Package/Package.package
@@ -21,20 +21,23 @@
     <customAssembly location="Microsoft.Kiota.Serialization.Json.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Kiota.Serialization.Json.dll" />
     <customAssembly location="Microsoft.Kiota.Serialization.Multipart.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Kiota.Serialization.Multipart.dll" />
     <customAssembly location="Microsoft.Kiota.Serialization.Text.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Kiota.Serialization.Text.dll" />
-    <customAssembly location="System.Buffers.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Buffers.dll" />
+    <customAssembly location="Std.UriTemplate.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Std.UriTemplate.dll" />   
+    <customAssembly location="System.Buffers.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Buffers.dll" /> 
     <customAssembly location="System.Diagnostics.DiagnosticSource.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Diagnostics.DiagnosticSource.dll" />
     <customAssembly location="System.IdentityModel.Tokens.Jwt.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.IdentityModel.Tokens.Jwt.dll" />
+    <customAssembly location="System.IO.FileSystem.AccessControl.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.IO.FileSystem.AccessControl.dll" />
     <customAssembly location="System.Memory.Data.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Memory.Data.dll" />
     <customAssembly location="System.Memory.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Memory.dll" />
     <customAssembly location="System.Net.Http.WinHttpHandler.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Net.Http.WinHttpHandler.dll" />
     <customAssembly location="System.Numerics.Vectors.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Numerics.Vectors.dll" />
     <customAssembly location="System.Runtime.CompilerServices.Unsafe.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Runtime.CompilerServices.Unsafe.dll" />
+    <customAssembly location="System.Security.AccessControl.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Security.AccessControl.dll" />
     <customAssembly location="System.Security.Cryptography.ProtectedData.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Security.Cryptography.ProtectedData.dll" />
+    <customAssembly location="System.Security.Principal.Windows.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Security.Principal.Windows.dll" />
     <customAssembly location="System.Text.Encodings.Web.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Text.Encodings.Web.dll" />
     <customAssembly location="System.Text.Json.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Text.Json.dll" />
     <customAssembly location="System.Threading.Tasks.Extensions.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Threading.Tasks.Extensions.dll" />
     <customAssembly location="System.ValueTuple.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.ValueTuple.dll" />
-    <customAssembly location="Tavis.UriTemplates.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Tavis.UriTemplates.dll" />
   </assemblies>
   <features>
     <featureReference itemId="70b104e2-19df-4cb1-9802-c98eaf14d84e" />

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/TroubleshootEntraCP.aspx
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/TroubleshootEntraCP.aspx
@@ -81,13 +81,9 @@
             try
             {
                 // Calling constructor of EntraIDTenant may throw FileNotFoundException on Azure.Identity
-                tenant = new EntraIDTenant
-                {
-                    Name = tenantName,
-                    ClientId = tenantClientId,
-                    ClientSecret = tenantClientSecret,
-                };
-
+                tenant = new EntraIDTenant(tenantName);
+                tenant.SetCredentials(tenantClientId, tenantClientSecret);
+                
                 // EntraIDTenant.InitializeAuthentication() will throw an exception if .NET cannot load one of the following assemblies:
                 // Azure.Core.dll, System.Diagnostics.DiagnosticSource.dll, Microsoft.IdentityModel.Abstractions.dll, System.Memory.dll, System.Runtime.CompilerServices.Unsafe.dll
                 tenant.InitializeAuthentication(ClaimsProviderConstants.DEFAULT_TIMEOUT, proxy);

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/TroubleshootEntraCP.aspx
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/TroubleshootEntraCP.aspx
@@ -55,10 +55,10 @@
             string[] urls = new string[] { "https://login.microsoftonline.com", "https://graph.microsoft.com" };
             foreach (string url in urls)
             {
+                Stopwatch timer = new Stopwatch();
+                timer.Start();
                 try
                 {
-                    Stopwatch timer = new Stopwatch();
-                    timer.Start();
                     // One difference VS EntraCP is that WebClient follows HTTP redirects, which, from URLs above, will take it to https://www.office.com/login and https://developer.microsoft.com/graph.
                     client.DownloadData(url);
                     //client.DownloadString(url);
@@ -67,7 +67,8 @@
                 }
                 catch (Exception ex)
                 {
-                    LblResult.Text += String.Format("<br/>Test connection to '{0}' through proxy '{1}' failed: {2}", url, proxyAddress, ex.GetType().Name + " - " + ex.Message);
+                    timer.Stop();
+                    LblResult.Text += String.Format("<br/>Test connection to '{0}' through proxy '{1}' failed after {2} ms: {3}", url, proxyAddress, timer.ElapsedMilliseconds, ex.GetType().Name + " - " + ex.Message);
                 }
             }
             return true;

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/TroubleshootEntraCP.aspx
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/TroubleshootEntraCP.aspx
@@ -5,6 +5,7 @@
 <%@ Import Namespace="System.IO" %>
 <%@ Import Namespace="System.Net" %>
 <%@ Import Namespace="System.Reflection" %>
+<%@ Import Namespace="System.Diagnostics" %>
 <%@ Import Namespace="System.Threading.Tasks" %>
 <%@ Import Namespace="Yvand.EntraClaimsProvider" %>
 <%@ Import Namespace="Yvand.EntraClaimsProvider.Configuration" %>
@@ -27,14 +28,10 @@
             string input = "yvand";
             string context = SPContext.Current.Web.Url;
 
-            EntraIDTenant tenant = new EntraIDTenant
-            {
-                Name = tenantName,
-                ClientId = tenantClientId,
-                ClientSecret = tenantClientSecret,
-            };
-            bool success = TestTenantConnectionAndAssemblyBindings(tenant, proxy);
-            if (success == false)
+            TestConnectionToEntraId(proxy);
+
+            EntraIDTenant tenant = TestTenantConnectionAndAssemblyBindings(tenantName, tenantClientId, tenantClientSecret, proxy);
+            if (tenant == null)
             {
                 return;
             }
@@ -48,10 +45,48 @@
             TestClaimsProviderAugmentation(claimsProvider, context, input);
         }
 
-        public bool TestTenantConnectionAndAssemblyBindings(EntraIDTenant tenant, string proxy)
+        public bool TestConnectionToEntraId(string proxyAddress)
         {
+            WebProxy proxy = String.IsNullOrWhiteSpace(proxyAddress) ? new WebProxy() : new WebProxy(proxyAddress, true);
+            WebClient client = new WebClient
+            {
+                Proxy = proxy,
+            };
+            string[] urls = new string[] { "https://login.microsoftonline.com", "https://graph.microsoft.com" };
+            foreach (string url in urls)
+            {
+                try
+                {
+                    Stopwatch timer = new Stopwatch();
+                    timer.Start();
+                    // One difference VS EntraCP is that WebClient follows HTTP redirects, which, from URLs above, will take it to https://www.office.com/login and https://developer.microsoft.com/graph.
+                    client.DownloadData(url);
+                    //client.DownloadString(url);
+                    timer.Stop();
+                    LblResult.Text += String.Format("<br/>Test connection to '{0}' through proxy '{1}': OK, took {2} ms.", url, proxyAddress, timer.ElapsedMilliseconds);
+                }
+                catch (Exception ex)
+                {
+                    LblResult.Text += String.Format("<br/>Test connection to '{0}' through proxy '{1}' failed: {2}", url, proxyAddress, ex.GetType().Name + " - " + ex.Message);
+                }
+            }
+            return true;
+        }
+
+        public EntraIDTenant TestTenantConnectionAndAssemblyBindings(string tenantName, string tenantClientId, string tenantClientSecret, string proxy)
+        {
+            EntraIDTenant tenant = null;
+            bool success = false;
             try
             {
+                // Calling constructor of EntraIDTenant may throw FileNotFoundException on Azure.Identity
+                tenant = new EntraIDTenant
+                {
+                    Name = tenantName,
+                    ClientId = tenantClientId,
+                    ClientSecret = tenantClientSecret,
+                };
+
                 // EntraIDTenant.InitializeAuthentication() will throw an exception if .NET cannot load one of the following assemblies:
                 // Azure.Core.dll, System.Diagnostics.DiagnosticSource.dll, Microsoft.IdentityModel.Abstractions.dll, System.Memory.dll, System.Runtime.CompilerServices.Unsafe.dll
                 tenant.InitializeAuthentication(ClaimsProviderConstants.DEFAULT_TIMEOUT, proxy);
@@ -61,21 +96,20 @@
                 // Azure.Identity.AuthenticationFailedException if invalid credentials 
                 Task<bool> taskTestConnection = Task.Run(async () => await tenant.TestConnectionAsync(proxy));
                 taskTestConnection.Wait();
-                bool success = taskTestConnection.Result;
+                success = taskTestConnection.Result;
                 LblResult.Text += String.Format("<br/>Test loading of dependencies: OK");
                 LblResult.Text += String.Format("<br/>Test connection to tenant '{0}': {1}", tenant.Name, success ? "OK" : "Failed");
-                return true;
             }
-            //catch (FileNotFoundException ex)
-            //{
-            //    LblResult.Text += String.Format("Test loading of dependencies: Failed. Check your assembly bindings in the machine.config file. Exception: '[0]'", ex.Message);
-            //}
+            catch (FileNotFoundException ex)
+            {
+                LblResult.Text += String.Format("<br/>Test loading of dependencies: Failed. Check your assembly bindings in the machine.config file. Exception: '{0}'", ex.Message);
+            }
             // An exception in an async task is always wrapped and returned in an AggregateException
             catch (AggregateException ex)
             {
                 if (ex.InnerException is FileNotFoundException)
                 {
-                    LblResult.Text += String.Format("Test loading of dependencies: Failed. Check your assembly bindings in the machine.config file. Exception: '[0]'", ex.InnerException.Message);
+                    LblResult.Text += String.Format("<br/>Test loading of dependencies: Failed. Check your assembly bindings in the machine.config file. Exception: '{0}'", ex.InnerException.Message);
                 }
                 else
                 {
@@ -87,15 +121,15 @@
                     }
                     else
                     {
-                        LblResult.Text += String.Format("<br/>Test connection to tenant '{0}' failed for an unknown reason: {1}", tenant.Name, ex.InnerException.Message);
+                        LblResult.Text += String.Format("<br/>Test connection to tenant '{0}' failed for an unknown reason: {1}", tenant.Name, ex.InnerException.GetType().Name + " - " + ex.InnerException.Message);
                     }
                 }
             }
             catch (Exception ex)
             {
-                LblResult.Text += String.Format("Unexpected error {0}: {1}", ex.GetType().Name, ex.Message);
+                LblResult.Text += String.Format("<br/>Unexpected error {0}: {1}", ex.GetType().Name, ex.Message);
             }
-            return false;
+            return success ? tenant : null;
         }
 
         public bool TestClaimsProviderSearch(EntraCP claimsProvider, string context, string input)

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/TroubleshootEntraCP.aspx
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/TroubleshootEntraCP.aspx
@@ -8,6 +8,8 @@
 <%@ Import Namespace="System.Threading.Tasks" %>
 <%@ Import Namespace="Yvand.EntraClaimsProvider" %>
 <%@ Import Namespace="Yvand.EntraClaimsProvider.Configuration" %>
+<%@ Import Namespace="Microsoft.SharePoint" %>
+<%@ Import Namespace="Microsoft.SharePoint.Administration.Claims" %>
 
 <asp:Content ID="PageTitle" ContentPlaceHolderID="PlaceHolderPageTitle" runat="server">Troubleshoot EntraCP</asp:Content>
 <asp:Content ID="PageTitleInTitleArea" ContentPlaceHolderID="PlaceHolderPageTitleInTitleArea" runat="server">Troubleshoot EntraCP in the context of current site</asp:Content>
@@ -16,67 +18,132 @@
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            // Variables proxy and tenant below can be replaced with actual values
-            string proxy = String.Empty;
+
+            // Edit the variables below with your own values
+            string tenantName = "ReplaceWithYourOwnValue";
+            string tenantClientId = "ReplaceWithYourOwnValue";
+            string tenantClientSecret = "ReplaceWithYourOwnValue";
+            string proxy = "";
+            string input = "yvand";
+            string context = SPContext.Current.Web.Url;
+
             EntraIDTenant tenant = new EntraIDTenant
             {
-                Name = "IDoNotExist",
-                ClientId = "IDoNotExist",
-                ClientSecret = "IDoNotExist",
+                Name = tenantName,
+                ClientId = tenantClientId,
+                ClientSecret = tenantClientSecret,
             };
+            bool success = TestTenantConnectionAndAssemblyBindings(tenant, proxy);
+            if (success == false)
+            {
+                return;
+            }
+
+            string claimsProviderName = "EntraCP";
+            EntraCPSettings settings = EntraCPSettings.GetDefaultSettings(claimsProviderName);
+            settings.EntraIDTenants.Add(tenant);
+            settings.ProxyAddress = proxy;
+            EntraCP claimsProvider = new EntraCP(claimsProviderName, settings);
+            TestClaimsProviderSearch(claimsProvider, context, input);
+            TestClaimsProviderAugmentation(claimsProvider, context, input);
+        }
+
+        public bool TestTenantConnectionAndAssemblyBindings(EntraIDTenant tenant, string proxy)
+        {
             try
             {
-                // The call to EntraIDTenant.InitializeAuthentication() tests if .NET can load the following assemblies:
-                // Azure.Core.dll
-                // System.Diagnostics.DiagnosticSource.dll
-                // Microsoft.IdentityModel.Abstractions.dll
-                // System.Memory.dll
-                // System.Runtime.CompilerServices.Unsafe.dll
-                tenant.InitializeAuthentication(10000, String.Empty);
+                // EntraIDTenant.InitializeAuthentication() will throw an exception if .NET cannot load one of the following assemblies:
+                // Azure.Core.dll, System.Diagnostics.DiagnosticSource.dll, Microsoft.IdentityModel.Abstractions.dll, System.Memory.dll, System.Runtime.CompilerServices.Unsafe.dll
+                tenant.InitializeAuthentication(ClaimsProviderConstants.DEFAULT_TIMEOUT, proxy);
 
-                // The call to EntraIDTenant.TestConnectionAsync() tests if .NET can load the following assembly: Microsoft.IdentityModel.Abstractions.dll
+                // EntraIDTenant.TestConnectionAsync() will throw exceptions:
+                // if .NET cannot load assembly Microsoft.IdentityModel.Abstractions.dll
+                // Azure.Identity.AuthenticationFailedException if invalid credentials 
                 Task<bool> taskTestConnection = Task.Run(async () => await tenant.TestConnectionAsync(proxy));
-                // If no valid credentials are set, this should throw an Azure.Identity.AuthenticationFailedException
                 taskTestConnection.Wait();
                 bool success = taskTestConnection.Result;
-                LblResult.Text = String.Format("Loading of all dependent assemblies was successful. Connection to tenant successful: {0}", success);
+                LblResult.Text += String.Format("<br/>Test loading of dependencies: OK");
+                LblResult.Text += String.Format("<br/>Test connection to tenant '{0}': {1}", tenant.Name, success ? "OK" : "Failed");
+                return true;
             }
-            catch (FileNotFoundException ex)
-            {
-                LblResult.Text = String.Format(".NET could not load an assembly, please check your assembly bindings in machine.config file, or .config file for current process. Exception details: {0}", ex.Message);
-            }
+            //catch (FileNotFoundException ex)
+            //{
+            //    LblResult.Text += String.Format("Test loading of dependencies: Failed. Check your assembly bindings in the machine.config file. Exception: '[0]'", ex.Message);
+            //}
             // An exception in an async task is always wrapped and returned in an AggregateException
             catch (AggregateException ex)
             {
                 if (ex.InnerException is FileNotFoundException)
                 {
-                    LblResult.Text = String.Format(".NET could not load an assembly, please check your assembly bindings in machine.config file, or .config file for current process. Exception details: {0}", ex.InnerException.Message);
+                    LblResult.Text += String.Format("Test loading of dependencies: Failed. Check your assembly bindings in the machine.config file. Exception: '[0]'", ex.InnerException.Message);
                 }
                 else
                 {
+                    LblResult.Text += String.Format("<br/>Test loading of dependencies: OK");
                     // Azure.Identity.AuthenticationFailedException is expected if credentials are not valid
                     if (String.Equals(ex.InnerException.GetType().FullName, "Azure.Identity.AuthenticationFailedException", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        LblResult.Text = String.Format("Loading of all dependent assemblies was successful.<br />Authentication to the tenant '{0}' failed: {1}", tenant.Name, ex.InnerException.Message);
+                        LblResult.Text += String.Format("<br/>Test connection to tenant '{0}' failed due to invalid credentials: {1}", tenant.Name, ex.InnerException.Message);
                     }
                     else
                     {
-                        LblResult.Text = ex.InnerException.Message;
+                        LblResult.Text += String.Format("<br/>Test connection to tenant '{0}' failed for an unknown reason: {1}", tenant.Name, ex.InnerException.Message);
                     }
                 }
             }
             catch (Exception ex)
             {
-                LblResult.Text = String.Format("Unexpected exception {0}: {1}", ex.GetType().Name, ex.Message);
+                LblResult.Text += String.Format("Unexpected error {0}: {1}", ex.GetType().Name, ex.Message);
             }
+            return false;
+        }
+
+        public bool TestClaimsProviderSearch(EntraCP claimsProvider, string context, string input)
+        {
+            try
+            {
+                var searchResult = claimsProvider.Search(new Uri(context), new[] { "User", "Group" }, input, null, 30);
+                int searchResultCount = 0;
+                if (searchResult != null)
+                {
+                    foreach (var children in searchResult.Children)
+                    {
+                        searchResultCount += children.EntityData.Count;
+                    }
+                }
+                LblResult.Text += String.Format("<br/>Test search with input '{0}' on '{1}': OK with {2} results returned.", input, context, searchResultCount);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LblResult.Text += String.Format("<br/>Test search with input '{0}' on '{1}': Failed: {2}", input, context, ex.Message);
+            }
+            return false;
+        }
+
+        public bool TestClaimsProviderAugmentation(EntraCP claimsProvider, string context, string input)
+        {
+            try
+            {
+                IdentityClaimTypeConfig idClaim = claimsProvider.Settings.ClaimTypes.IdentityClaim;
+                string originalIssuer = SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, Utils.GetSPTrustAssociatedWithClaimsProvider("EntraCP").Name);
+                SPClaim claim = new SPClaim(idClaim.ClaimType, input, idClaim.ClaimValueType, originalIssuer);
+                // TODO: Somehow, from this page claimsProvider.GetClaimsForEntity() causes a hang
+                //SPClaim[] groups = claimsProvider.GetClaimsForEntity(new Uri(context), claim);
+                //LblResult.Text += String.Format("<br/>Test augmentation for user '{0}' on '{1}': OK with {2} groups returned.", input, context, groups == null ? 0 : groups.Length);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LblResult.Text += String.Format("<br/>Test augmentation for user '{0}' on '{1}': Failed: {2}", input, context, ex.Message);
+            }
+            return false;
         }
     </script>
-    This page primarily verifies if the .NET assembly bindings are correctly set.<br />
-    It also tries to connect to Microsoft Entra ID, but it uses hardcoded, fake credentials by default.<br />
-    It has no code behind, it is written entirely using inline code, so you can easily customize it (and set valid credentials).<br />
+    This page helps you troubleshoot EntraCP with minimal overhead, directly in the context of SharePoint sites.<br />
+    It is written entirely using inline code, so you can easily customize it (and set valid credentials).<br />
     For security reasons, by default it can only be called from the central administration, but you can simply copy it in the LAYOUTS folder, to call it from any SharePoint web application.<br />
     <br />
-    Result of the tests:<br />
     <asp:Literal ID="LblResult" runat="server" Text="" />
     <%--<asp:TextBox ID="TxtUrl" runat="server" CssClass="ms-inputformcontrols" Text="URL..."></asp:TextBox>--%>
 </asp:Content>

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/TroubleshootEntraCP.aspx
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/TroubleshootEntraCP.aspx
@@ -83,7 +83,7 @@
                 // Calling constructor of EntraIDTenant may throw FileNotFoundException on Azure.Identity
                 tenant = new EntraIDTenant(tenantName);
                 tenant.SetCredentials(tenantClientId, tenantClientSecret);
-                
+
                 // EntraIDTenant.InitializeAuthentication() will throw an exception if .NET cannot load one of the following assemblies:
                 // Azure.Core.dll, System.Diagnostics.DiagnosticSource.dll, Microsoft.IdentityModel.Abstractions.dll, System.Memory.dll, System.Runtime.CompilerServices.Unsafe.dll
                 tenant.InitializeAuthentication(ClaimsProviderConstants.DEFAULT_TIMEOUT, proxy);
@@ -159,9 +159,8 @@
                 IdentityClaimTypeConfig idClaim = claimsProvider.Settings.ClaimTypes.IdentityClaim;
                 string originalIssuer = SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, Utils.GetSPTrustAssociatedWithClaimsProvider("EntraCP").Name);
                 SPClaim claim = new SPClaim(idClaim.ClaimType, input, idClaim.ClaimValueType, originalIssuer);
-                // TODO: Somehow, from this page claimsProvider.GetClaimsForEntity() causes a hang
-                //SPClaim[] groups = claimsProvider.GetClaimsForEntity(new Uri(context), claim);
-                //LblResult.Text += String.Format("<br/>Test augmentation for user '{0}' on '{1}': OK with {2} groups returned.", input, context, groups == null ? 0 : groups.Length);
+                SPClaim[] groups = claimsProvider.GetClaimsForEntity(new Uri(context), claim);
+                LblResult.Text += String.Format("<br/>Test augmentation for user '{0}' on '{1}': OK with {2} groups returned.", input, context, groups == null ? 0 : groups.Length);
                 return true;
             }
             catch (Exception ex)

--- a/Yvand.EntraCP/Yvand.EntraCP.csproj
+++ b/Yvand.EntraCP/Yvand.EntraCP.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Yvand.EntraClaimsProvider\Administration\EntraCPUserControl.cs">
       <SubType>ASPXCodeBehind</SubType>
     </Compile>
+    <Compile Include="Yvand.EntraClaimsProvider\GraphRequestsLogging.cs" />
     <Compile Include="Yvand.EntraClaimsProvider\Logger.cs" />
     <Compile Include="Yvand.EntraClaimsProvider\Configuration\EntraIDTenant.cs" />
     <Compile Include="Yvand.EntraClaimsProvider\Configuration\ClaimsProviderConstants.cs" />

--- a/Yvand.EntraCP/Yvand.EntraCP.csproj
+++ b/Yvand.EntraCP/Yvand.EntraCP.csproj
@@ -127,10 +127,10 @@
   <!-- NuGet packages -->
   <ItemGroup>
     <PackageReference Include="Azure.Identity">
-      <Version>1.10.1</Version>
+      <Version>1.10.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph">
-      <Version>5.27.0</Version>
+      <Version>5.29.0</Version>
     </PackageReference>
     <PackageReference Include="StrongNamer">
       <Version>0.2.5</Version>

--- a/Yvand.EntraCP/Yvand.EntraCP.csproj
+++ b/Yvand.EntraCP/Yvand.EntraCP.csproj
@@ -128,10 +128,10 @@
   <!-- NuGet packages -->
   <ItemGroup>
     <PackageReference Include="Azure.Identity">
-      <Version>1.10.2</Version>
+      <Version>1.10.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph">
-      <Version>5.29.0</Version>
+      <Version>5.34.0</Version>
     </PackageReference>
     <PackageReference Include="StrongNamer">
       <Version>0.2.5</Version>
@@ -182,19 +182,22 @@ copy /Y "$(TargetDir)Microsoft.Kiota.Serialization.Form.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Kiota.Serialization.Json.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Kiota.Serialization.Multipart.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Kiota.Serialization.Text.dll" $(ProjectDir)\bin
+copy /Y "$(TargetDir)Std.UriTemplate.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Buffers.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Diagnostics.DiagnosticSource.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.IdentityModel.Tokens.Jwt.dll" $(ProjectDir)\bin
+copy /Y "$(TargetDir)System.IO.FileSystem.AccessControl.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Memory.Data.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Memory.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Net.Http.WinHttpHandler.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Numerics.Vectors.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Runtime.CompilerServices.Unsafe.dll" $(ProjectDir)\bin
+copy /Y "$(TargetDir)System.Security.AccessControl.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Security.Cryptography.ProtectedData.dll" $(ProjectDir)\bin
+copy /Y "$(TargetDir)System.Security.Principal.Windows.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Text.Encodings.Web.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Text.Json.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Threading.Tasks.Extensions.dll" $(ProjectDir)\bin
-copy /Y "$(TargetDir)System.ValueTuple.dll" $(ProjectDir)\bin
-copy /Y "$(TargetDir)Tavis.UriTemplates.dll" $(ProjectDir)\bin</PostBuildEvent>
+copy /Y "$(TargetDir)System.ValueTuple.dll" $(ProjectDir)\bin</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -68,9 +68,9 @@ namespace Yvand.EntraClaimsProvider.Configuration
         }
 
 #if DEBUG
-        public static int DEFAULT_TIMEOUT => 10000;
+        public static int DEFAULT_TIMEOUT = 10 * 1000;
 #else
-        public static int DEFAULT_TIMEOUT => 4000;    // 4 secs
+        public static int DEFAULT_TIMEOUT = 40 * 1000;    // 40 secs
 #endif
     }
 

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -70,7 +70,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
 #if DEBUG
         public static int DEFAULT_TIMEOUT = 10 * 1000;
 #else
-        public static int DEFAULT_TIMEOUT = 4 * 1000;    // 40 secs
+        public static int DEFAULT_TIMEOUT = 15 * 1000;
 #endif
     }
 

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -70,7 +70,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
 #if DEBUG
         public static int DEFAULT_TIMEOUT = 10 * 1000;
 #else
-        public static int DEFAULT_TIMEOUT = 40 * 1000;    // 40 secs
+        public static int DEFAULT_TIMEOUT = 4 * 1000;    // 40 secs
 #endif
     }
 

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
@@ -91,6 +91,15 @@ namespace Yvand.EntraClaimsProvider.Configuration
 
         public EntraIDProviderSettings() { }
 
+        public static EntraIDProviderSettings GetDefaultSettings(string claimsProviderName)
+        {
+            EntraIDProviderSettings entityProviderSettings = new EntraIDProviderSettings
+            {
+                ClaimTypes = EntraIDProviderSettings.ReturnDefaultClaimTypesConfig(claimsProviderName),
+            };
+            return entityProviderSettings;
+        }
+
         /// <summary>
         /// Returns the default claim types configuration list, based on the identity claim type set in the TrustedLoginProvider associated with <paramref name="claimProviderName"/>
         /// </summary>
@@ -468,11 +477,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
 
         public virtual IEntraIDProviderSettings GetDefaultSettings()
         {
-            IEntraIDProviderSettings entityProviderSettings = new EntraIDProviderSettings
-            {
-                ClaimTypes = EntraIDProviderSettings.ReturnDefaultClaimTypesConfig(this.ClaimsProviderName),
-            };
-            return (IEntraIDProviderSettings)entityProviderSettings;
+            return EntraIDProviderSettings.GetDefaultSettings(this.ClaimsProviderName);
         }
 
         /// <summary>

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
@@ -138,6 +138,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
 
     public class EntraIDProviderConfiguration : SPPersistedObject, IEntraIDProviderSettings
     {
+        public string LocalAssemblyVersion => ClaimsProviderConstants.ClaimsProviderVersion;
         /// <summary>
         /// Gets the settings, based on the configuration stored in this persisted object
         /// </summary>
@@ -155,6 +156,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
         private IEntraIDProviderSettings _Settings;
 
         #region "Base settings implemented from IEntraIDEntityProviderSettings"
+
         public ClaimTypeConfigCollection ClaimTypes
         {
             get
@@ -287,7 +289,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
                 return this._SPTrust;
             }
         }
-        #endregion       
+        #endregion
 
         public EntraIDProviderConfiguration() { }
         public EntraIDProviderConfiguration(string persistedObjectName, SPPersistedObject parent, string claimsProviderName) : base(persistedObjectName, parent)

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
@@ -42,7 +42,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
         string EntityDisplayTextPrefix { get; }
 
         /// <summary>
-        /// Gets or sets the timeout before giving up the query to Microsoft Entra ID.
+        /// Gets or sets the timeout in milliseconds before an operation to Microsoft Entra ID is canceled.
         /// </summary>
         int Timeout { get; }
 
@@ -222,9 +222,6 @@ namespace Yvand.EntraClaimsProvider.Configuration
         {
             get
             {
-#if DEBUG
-                return _Timeout * 100;
-#endif
                 return _Timeout;
             }
             private set => _Timeout = value;

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
@@ -153,6 +153,11 @@ namespace Yvand.EntraClaimsProvider.Configuration
         public string[] GroupSelect { get; set; }
 
         public EntraIDTenant() { }
+        
+        public EntraIDTenant(string tenantName) 
+        {
+            this.Name = tenantName;
+        }
 
         protected override void OnDeserialization()
         {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
@@ -8,10 +8,12 @@ using Microsoft.Kiota.Http.HttpClientLibrary.Middleware.Options;
 using Microsoft.SharePoint.Administration;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Runtime.ConstrainedExecution;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -29,7 +31,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
         private Guid _Identifier = Guid.NewGuid();
 
         /// <summary>
-        /// Tenant Name or ID
+        /// Gets or sets the tenant name (TENANTNAME.onMicrosoft.com) or ID (GUID)
         /// </summary>
         public string Name
         {
@@ -40,7 +42,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
         private string _Name;
 
         /// <summary>
-        /// Application (client) ID of the app registration created for EntraCP in the Microsoft Entra ID tenant
+        /// Gets or sets the application (client) ID used to authenticate in the Microsoft Entra ID tenant
         /// </summary>
         public string ClientId
         {
@@ -51,46 +53,18 @@ namespace Yvand.EntraClaimsProvider.Configuration
         private string _ClientId;
 
         /// <summary>
-        /// Client secret of the app registration created for EntraCP in the Microsoft Entra ID tenant
+        /// Gets the client secret used to authenticate in the Microsoft Entra ID tenant
         /// </summary>
         public string ClientSecret
         {
             get => _ClientSecret;
-            set => _ClientSecret = value;
+            protected set => _ClientSecret = value;
         }
         [Persisted]
         private string _ClientSecret;
 
-        public bool ExcludeMemberUsers
-        {
-            get => _ExcludeMemberUsers;
-            set => _ExcludeMemberUsers = value;
-        }
-        [Persisted]
-        private bool _ExcludeMemberUsers = false;
-
-        public bool ExcludeGuestUsers
-        {
-            get => _ExcludeGuestUsers;
-            set => _ExcludeGuestUsers = value;
-        }
-        [Persisted]
-        private bool _ExcludeGuestUsers = false;
-
         /// <summary>
-        /// Client ID of AD Connect used in extension attribues
-        /// </summary>
-        [Persisted]
-        private Guid _ExtensionAttributesApplicationId;
-
-        public Guid ExtensionAttributesApplicationId
-        {
-            get => _ExtensionAttributesApplicationId;
-            set => _ExtensionAttributesApplicationId = value;
-        }
-
-        /// <summary>
-        /// Gets or set the client certificate with its private key, configured in the app registration for EntraCP
+        /// Gets the client certificate with its private key, used to authenticate in the Microsoft Entra ID tenant
         /// </summary>
         public X509Certificate2 ClientCertificateWithPrivateKey
         {
@@ -98,7 +72,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
             {
                 return _ClientCertificateWithPrivateKey;
             }
-            set
+            protected set
             {
                 if (value == null) { return; }
                 if (!value.HasPrivateKey) { throw new ArgumentException("The certificate cannot be imported because it does not have a private key"); }
@@ -118,6 +92,34 @@ namespace Yvand.EntraClaimsProvider.Configuration
         private X509Certificate2 _ClientCertificateWithPrivateKey;
         [Persisted]
         private byte[] _ClientCertificateWithPrivateKeyRawData;
+
+        public bool ExcludeMemberUsers
+        {
+            get => _ExcludeMemberUsers;
+            set => _ExcludeMemberUsers = value;
+        }
+        [Persisted]
+        private bool _ExcludeMemberUsers = false;
+
+        public bool ExcludeGuestUsers
+        {
+            get => _ExcludeGuestUsers;
+            set => _ExcludeGuestUsers = value;
+        }
+        [Persisted]
+        private bool _ExcludeGuestUsers = false;
+
+        [Persisted]
+        private Guid _ExtensionAttributesApplicationId;
+
+        /// <summary>
+        /// Gets or sets the client ID used for the extension attribues
+        /// </summary>
+        public Guid ExtensionAttributesApplicationId
+        {
+            get => _ExtensionAttributesApplicationId;
+            set => _ExtensionAttributesApplicationId = value;
+        }
 
         public Uri AzureAuthority
         {
@@ -160,7 +162,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
                 {
                     // Sets the local X509Certificate2 object from the persisted raw data stored in the configuration database
                     // EphemeralKeySet: Keep the private key in-memory, it won't be written to disk - https://www.pkisolutions.com/handling-x509keystorageflags-in-applications/
-                    _ClientCertificateWithPrivateKey = ImportPfxCertificateBlob(_ClientCertificateWithPrivateKeyRawData, ClaimsProviderConstants.ClientCertificatePrivateKeyPassword, X509KeyStorageFlags.EphemeralKeySet);
+                    _ClientCertificateWithPrivateKey = ImportPfxCertificate(_ClientCertificateWithPrivateKeyRawData, ClaimsProviderConstants.ClientCertificatePrivateKeyPassword);
                 }
                 catch (CryptographicException ex)
                 {
@@ -308,51 +310,94 @@ namespace Yvand.EntraClaimsProvider.Configuration
         }
 
         /// <summary>
-        /// Sets the credentials used to connect to the Microsoft Entra ID tenant
+        /// Sets the credentials with a client secret, to connect to the Microsoft Entra ID tenant
         /// </summary>
         /// <param name="clientId">Application (client) ID</param>
         /// <param name="clientSecret">Application (client) secret</param>
-        public void SetCredentials(string clientId, string clientSecret)
+        public bool SetCredentials(string clientId, string clientSecret)
         {
             this.ClientId = clientId;
             this.ClientSecret = clientSecret;
             this.ClientCertificateWithPrivateKey = null;
+            return true;
         }
 
         /// <summary>
-        /// Sets the credentials used to connect to the Microsoft Entra ID tenant
+        /// Sets the credentials with a client certificate, to connect to the Microsoft Entra ID tenant
         /// </summary>
-        /// <param name="clientId">Application (client) secret</param>
+        /// <param name="clientId">Application (client) ID</param>
         /// <param name="clientCertificateWithPrivateKey">Client certificate with its private key</param>
-        public void SetCredentials(string clientId, X509Certificate2 clientCertificateWithPrivateKey)
+        /// <returns></returns>
+        public bool SetCredentials(string clientId, X509Certificate2 clientCertificateWithPrivateKey)
         {
             this.ClientId = clientId;
             this.ClientSecret = String.Empty;
             this.ClientCertificateWithPrivateKey = clientCertificateWithPrivateKey;
+            return true;
         }
 
         /// <summary>
-        /// Imports the input blob into a pfx X509Certificate2 object with its private key
+        /// Sets the credentials with a client certificate, to connect to the Microsoft Entra ID tenant
         /// </summary>
-        /// <param name="blob"></param>
-        /// <param name="certificatePassword"></param>
-        /// <param name="keyStorageFlags"></param>
-        /// <returns></returns>
-        public static X509Certificate2 ImportPfxCertificateBlob(byte[] blob, string certificatePassword, X509KeyStorageFlags keyStorageFlags)
+        /// <param name="clientId">Application (client) ID</param>
+        /// <param name="clientCertificatePfxFilePath">File path to the client certificate</param>
+        /// <param name="clientCertificatePfxPassword">Optional password of the client certificate</param>
+        public bool SetCredentials(string clientId, string clientCertificatePfxFilePath, string clientCertificatePfxPassword)
         {
-            if (X509Certificate2.GetCertContentType(blob) != X509ContentType.Pfx)
+            this.ClientId = clientId;
+            this.ClientSecret = String.Empty;
+            X509Certificate2 cert = EntraIDTenant.ImportPfxCertificate(clientCertificatePfxFilePath, clientCertificatePfxPassword);
+            if (cert == null) { return false; }
+            this.ClientCertificateWithPrivateKey = cert;
+            return true;
+        }
+
+        /// <summary>
+        /// Imports the raw certificate into an exportable X509Certificate2 object with its private key
+        /// </summary>
+        /// <param name="rawData"></param>
+        /// <param name="certificatePassword"></param>
+        /// <returns></returns>
+        public static X509Certificate2 ImportPfxCertificate(byte[] rawData, string certificatePassword)
+        {
+            if (X509Certificate2.GetCertContentType(rawData) != X509ContentType.Pfx)
             {
                 return null;
             }
 
+            X509KeyStorageFlags certificateFlags = X509KeyStorageFlags.Exportable | X509KeyStorageFlags.EphemeralKeySet;
             if (String.IsNullOrWhiteSpace(certificatePassword))
             {
                 // If passwordless, import the private key as documented in https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b
-                return new X509Certificate2(blob, (string)null, keyStorageFlags);
+                return new X509Certificate2(rawData, (string)null, certificateFlags);
             }
             else
             {
-                return new X509Certificate2(blob, certificatePassword, keyStorageFlags);
+                return new X509Certificate2(rawData, certificatePassword, certificateFlags);
+            }
+        }
+
+        public static X509Certificate2 ImportPfxCertificate(string clientCertificatePfxFilePath, string certificatePassword)
+        {
+            if (File.Exists(clientCertificatePfxFilePath) == false)
+            {
+                return null;
+            }
+
+            if (X509Certificate2.GetCertContentType(clientCertificatePfxFilePath) != X509ContentType.Pfx)
+            {
+                return null;
+            }
+
+            X509KeyStorageFlags certificateFlags = X509KeyStorageFlags.Exportable | X509KeyStorageFlags.EphemeralKeySet;
+            if (String.IsNullOrWhiteSpace(certificatePassword))
+            {
+                // If passwordless, import the private key as documented in https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b
+                return new X509Certificate2(clientCertificatePfxFilePath, (string)null, certificateFlags);
+            }
+            else
+            {
+                return new X509Certificate2(clientCertificatePfxFilePath, certificatePassword, certificateFlags);
             }
         }
     }

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
@@ -58,7 +58,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
         public string ClientSecret
         {
             get => _ClientSecret;
-            protected set => _ClientSecret = value;
+            set => _ClientSecret = value;
         }
         [Persisted]
         private string _ClientSecret;
@@ -210,12 +210,12 @@ namespace Yvand.EntraClaimsProvider.Configuration
             var handlers = GraphClientFactory.CreateDefaultHandlers(new GraphClientOptions { GraphProductPrefix = "EntraCP" });
             handlers.Add(new GraphRequestsLogging());
 #if DEBUG
-            handlers.Add(new ChaosHandler(new ChaosHandlerOption()
-            {
-                ChaosPercentLevel = 50
-            }));
-            var retryHandler = handlers.Where(h => h is RetryHandler).FirstOrDefault();
-            handlers.Remove(retryHandler);
+            //handlers.Add(new ChaosHandler(new ChaosHandlerOption()
+            //{
+            //    ChaosPercentLevel = 50
+            //}));
+            //var retryHandler = handlers.Where(h => h is RetryHandler).FirstOrDefault();
+            //handlers.Remove(retryHandler);
 #endif
 
             TokenCredentialOptions options = new TokenCredentialOptions

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraCP.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraCP.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Graph.Models;
+﻿using Azure.Core.Diagnostics;
+using Microsoft.Graph.Models;
 using Microsoft.SharePoint.Administration;
 using Microsoft.SharePoint.Administration.Claims;
 using Microsoft.SharePoint.Utilities;
@@ -6,6 +7,7 @@ using Microsoft.SharePoint.WebControls;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -49,6 +51,7 @@ namespace Yvand.EntraClaimsProvider
         protected virtual string PickerEntityOnMouseOver => "{0}={1}";
         public IEntraCPSettings Settings { get; protected set; }
         public long SettingsVersion { get; private set; } = -1;
+        AzureEventSourceListener listener;
         #region "Runtime settings"
         //protected List<ClaimTypeConfig> RuntimeClaimTypesList { get; private set; }
         //protected IEnumerable<ClaimTypeConfig> RuntimeMetadataConfig { get; private set; }
@@ -79,6 +82,13 @@ namespace Yvand.EntraClaimsProvider
         public EntraCP(string displayName) : base(displayName)
         {
             this.EntityProvider = new EntraIDEntityProvider(Name);
+            this.listener = new AzureEventSourceListener((args, message) =>
+            {
+                if (args.EventSource.Name == "Azure-Identity")
+                {
+                    Logger.Log($"[{EntraCP.ClaimsProviderName}] {args.EventName} {message}", Utils.EventLogToTraceSeverity(args.Level), EventSeverity.Error, TraceCategory.AzureIdentity);
+                }
+            }, EventLevel.Informational);
         }
 
         public static EntraIDProviderConfiguration GetConfiguration(bool initializeLocalConfiguration = false)

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
@@ -71,10 +71,10 @@ namespace Yvand.EntraClaimsProvider
                         // But it returns only the group IDs so it can be used only if groupClaimTypeConfig.DirectoryObjectProperty == AzureADObjectProperty.Id
                         // For Guest users, it must be the id: POST to /v1.0/users/18ff6ae9-dd01-4008-a786-aabf71f1492a/microsoft.graph.getMemberGroups
                         GetMemberGroupsPostRequestBody getGroupsOptions = new GetMemberGroupsPostRequestBody { SecurityEnabledOnly = currentContext.Settings.FilterSecurityEnabledGroupsOnly };
-                        GetMemberGroupsResponse memberGroupsResponse = await Task.Run(() => tenant.GraphService.Users[user.Id].GetMemberGroups.PostAsync(getGroupsOptions)).ConfigureAwait(false);
+                        GetMemberGroupsPostResponse memberGroupsResponse = await Task.Run(() => tenant.GraphService.Users[user.Id].GetMemberGroups.PostAsGetMemberGroupsPostResponseAsync(getGroupsOptions)).ConfigureAwait(false);
                         if (memberGroupsResponse?.Value != null)
                         {
-                            PageIterator<string, GetMemberGroupsResponse> memberGroupsPageIterator = PageIterator<string, GetMemberGroupsResponse>.CreatePageIterator(
+                            PageIterator<string, GetMemberGroupsPostResponse> memberGroupsPageIterator = PageIterator<string, GetMemberGroupsPostResponse>.CreatePageIterator(
                             tenant.GraphService,
                             memberGroupsResponse,
                             (groupId) =>

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
@@ -441,17 +441,31 @@ namespace Yvand.EntraClaimsProvider
                     // Check if the users' request in the batch request was successful. If so, get the users that were returned by Graph
                     HttpStatusCode usersRequestStatus;
                     UserCollectionResponse userCollectionResult = null;
-                    if (requestsStatusInBatchResponse.TryGetValue(usersRequestId, out usersRequestStatus) && usersRequestStatus == HttpStatusCode.OK)
+                    if (requestsStatusInBatchResponse.TryGetValue(usersRequestId, out usersRequestStatus))
                     {
-                        userCollectionResult = await batchResponse.GetResponseByIdAsync<UserCollectionResponse>(usersRequestId).ConfigureAwait(false);
+                        if (usersRequestStatus == HttpStatusCode.OK)
+                        {
+                            userCollectionResult = await batchResponse.GetResponseByIdAsync<UserCollectionResponse>(usersRequestId).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            Logger.Log($"[{ClaimsProviderName}] Query to tenant '{tenant.Name}' returned unexpected status '{usersRequestStatus}' for users request with filter \"{tenant.UserFilter}\"", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Lookup);
+                        }
                     }
 
                     // Check if the groups' request in the batch request was successful. If so, get the users that were returned by Graph
                     HttpStatusCode groupRequestStatus;
                     GroupCollectionResponse groupCollectionResult = null;
-                    if (requestsStatusInBatchResponse.TryGetValue(usersRequestId, out groupRequestStatus) && groupRequestStatus == HttpStatusCode.OK)
+                    if (requestsStatusInBatchResponse.TryGetValue(groupsRequestId, out groupRequestStatus))
                     {
-                        groupCollectionResult = await batchResponse.GetResponseByIdAsync<GroupCollectionResponse>(groupsRequestId).ConfigureAwait(false);
+                        if (groupRequestStatus == HttpStatusCode.OK)
+                        {
+                            groupCollectionResult = await batchResponse.GetResponseByIdAsync<GroupCollectionResponse>(groupsRequestId).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            Logger.Log($"[{ClaimsProviderName}] Query to tenant '{tenant.Name}' returned unexpected status '{groupRequestStatus}' for groups request with filter \"{tenant.GroupFilter}\"", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Lookup);
+                        }
                     }
 
                     Logger.Log($"[{ClaimsProviderName}] Query to tenant '{tenant.Name}' returned {(userCollectionResult?.Value == null ? 0 : userCollectionResult.Value.Count)} user(s) with filter \"{tenant.UserFilter}\"", TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Lookup);

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
@@ -468,7 +468,7 @@ namespace Yvand.EntraClaimsProvider
                         }
                     }
 
-                    Logger.Log($"[{ClaimsProviderName}] Query to tenant '{tenant.Name}' returned {(userCollectionResult?.Value == null ? 0 : userCollectionResult.Value.Count)} user(s) with filter \"{tenant.UserFilter}\"", TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Lookup);
+                    Logger.Log($"[{ClaimsProviderName}] Query to tenant '{tenant.Name}' returned {(userCollectionResult?.Value == null ? 0 : userCollectionResult.Value.Count)} user(s) with filter \"{tenant.UserFilter}\" and {(groupCollectionResult?.Value == null ? 0 : groupCollectionResult.Value.Count)} group(s) with filter \"{tenant.GroupFilter}\"", TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Lookup);
                     // Process users result
                     if (userCollectionResult?.Value != null)
                     {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Yvand.EntraClaimsProvider.Configuration;
 
@@ -102,6 +103,10 @@ namespace Yvand.EntraClaimsProvider
                             await memberGroupsPageIterator.IterateAsync().ConfigureAwait(false);
                         }
                     }
+                }
+                catch (TaskCanceledException ex)
+                {
+                    Logger.LogException(ClaimsProviderName, $"while getting groups for user '{currentContext.IncomingEntity.Value}' from tenant '{tenant.Name}': The task likely exceeded the timeout of {currentContext.Settings.Timeout} ms and was canceled", TraceCategory.Augmentation, ex);
                 }
                 catch (Exception ex)
                 {
@@ -550,7 +555,7 @@ namespace Yvand.EntraClaimsProvider
             }
             catch (OperationCanceledException)
             {
-                Logger.Log($"[{ClaimsProviderName}] Queries on Microsoft Entra ID tenant '{tenant.Name}' exceeded timeout of {timeout} ms and were cancelled.", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Lookup);
+                Logger.Log($"[{ClaimsProviderName}] Operation on Entra ID for tenant '{tenant.Name}' exceeded the timeout of {timeout} ms and was cancelled.", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Lookup);
             }
             catch (AuthenticationFailedException ex)
             {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/GraphRequestsLogging.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/GraphRequestsLogging.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.SharePoint.Administration;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Yvand.EntraClaimsProvider
+{
+    /// <summary>
+    /// Capture the requests to Graph to record them in the SharePoint logs.
+    /// This does not capture the authentication traffic.
+    /// Doc: https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/blob/dev/docs/logging-requests.md
+    /// </summary>
+    public class GraphRequestsLogging : DelegatingHandler
+    {
+
+        public GraphRequestsLogging()
+        {
+        }
+
+        /// <summary>
+        /// Sends a HTTP request.
+        /// </summary>
+        /// <param name="httpRequest">The <see cref="HttpRequestMessage"/> to be sent.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns></returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequest, CancellationToken cancellationToken)
+        {
+            HttpResponseMessage response = await base.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode == false)
+            {
+                // httpRequest.Content is null if httpRequest is a GET (e.g. during augmentation)
+                string requestBody = httpRequest.Content == null ? string.Empty : await httpRequest.Content.ReadAsStringAsync().ConfigureAwait(false);
+                Logger.Log($"[{EntraCP.ClaimsProviderName}] Graph returned error {response.StatusCode} {response.ReasonPhrase} on request \"{httpRequest.RequestUri}\" with JSON payload \"{requestBody}\"", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.GraphRequests);
+            }
+            else
+            {
+                // Log in VerboseEx because as is, those messages aren't really useful
+                Logger.Log($"[{EntraCP.ClaimsProviderName}] Graph returned success {response.StatusCode} on request \"{httpRequest.RequestUri}\"", TraceSeverity.VerboseEx, EventSeverity.Verbose, TraceCategory.GraphRequests);
+            }
+            return response;
+        }
+    }
+}

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Logger.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Logger.cs
@@ -62,7 +62,8 @@ namespace Yvand.EntraClaimsProvider
     {
         public readonly static string DiagnosticsAreaName = EntraCP.ClaimsProviderName;
 
-        public override string Name => $"{DiagnosticsAreaName}.Logging";
+        // This property causes a TypeLoadException in SharePoint 2016 (not tested with 2019) because: Cannot override inherited member 'SPPersistedObject.Name' because it is not marked virtual, abstract, or override
+        //public override string Name => $"{DiagnosticsAreaName}.Logging";
 
         public static void Log(string message, TraceSeverity traceSeverity, EventSeverity eventSeverity, TraceCategory category)
         {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Logger.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Logger.cs
@@ -62,8 +62,8 @@ namespace Yvand.EntraClaimsProvider
     {
         public readonly static string DiagnosticsAreaName = EntraCP.ClaimsProviderName;
 
-        // This property causes a TypeLoadException in SharePoint 2016 (not tested with 2019) because: Cannot override inherited member 'SPPersistedObject.Name' because it is not marked virtual, abstract, or override
-        //public override string Name => $"{DiagnosticsAreaName}.Logging";
+        // This property causes a TypeLoadException in SharePoint 2016 RTM (not in 2023-11 CU and not in 2019) because: Cannot override inherited member 'SPPersistedObject.Name' because it is not marked virtual, abstract, or override
+        public override string Name => $"{DiagnosticsAreaName}.Logging";
 
         public static void Log(string message, TraceSeverity traceSeverity, EventSeverity eventSeverity, TraceCategory category)
         {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Logger.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Logger.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Yvand.EntraClaimsProvider
@@ -43,6 +44,14 @@ namespace Yvand.EntraClaimsProvider
          DefaultTraceSeverity(TraceSeverity.Medium),
          DefaultEventSeverity(EventSeverity.Error)]
         Custom,
+        [CategoryName("Azure Identity"),
+         DefaultTraceSeverity(TraceSeverity.Medium),
+         DefaultEventSeverity(EventSeverity.Error)]
+        AzureIdentity,
+        [CategoryName("Graph Requests"),
+         DefaultTraceSeverity(TraceSeverity.Medium),
+         DefaultEventSeverity(EventSeverity.Error)]
+        GraphRequests,
     }
 
     /// <summary>
@@ -52,6 +61,8 @@ namespace Yvand.EntraClaimsProvider
     public class Logger : SPDiagnosticsServiceBase
     {
         public readonly static string DiagnosticsAreaName = EntraCP.ClaimsProviderName;
+
+        public override string Name => $"{DiagnosticsAreaName}.Logging";
 
         public static void Log(string message, TraceSeverity traceSeverity, EventSeverity eventSeverity, TraceCategory category)
         {
@@ -80,11 +91,11 @@ namespace Yvand.EntraClaimsProvider
                         string currentMessage;
                         if (innerEx.InnerException != null)
                         {
-                            currentMessage = String.Format(excetpionMessage, count++.ToString(), innerEx.InnerException.GetType().FullName, innerEx.InnerException.Message);
+                            currentMessage = String.Format(excetpionMessage, count++.ToString(), innerEx.InnerException.GetType().Name, innerEx.InnerException.Message);
                         }
                         else
                         {
-                            currentMessage = String.Format(excetpionMessage, count++.ToString(), innerEx.GetType().FullName, innerEx.Message);
+                            currentMessage = String.Format(excetpionMessage, count++.ToString(), innerEx.GetType().Name, innerEx.Message);
                         }
                         message.Append(currentMessage);
                     }
@@ -106,14 +117,14 @@ namespace Yvand.EntraClaimsProvider
                 }
                 else
                 {
-                    errorNessage = "[{0}] Unexpected error {1}: {2}: {3}, Callstack: {4}";
-                    if (ex.InnerException != null)
+                    errorNessage = "[{0}] Unexpected error {1}: {2}: {3}";
+                    if (ex.InnerException != null && !(ex.InnerException is AggregateException))
                     {
-                        errorNessage = String.Format(errorNessage, claimsProviderName, customMessage, ex.InnerException.GetType().FullName, ex.InnerException.Message, ex.InnerException.StackTrace);
+                        errorNessage = String.Format(errorNessage, claimsProviderName, customMessage, ex.InnerException.GetType().Name, ex.InnerException.Message);
                     }
                     else
                     {
-                        errorNessage = String.Format(errorNessage, claimsProviderName, customMessage, ex.GetType().FullName, ex.Message, ex.StackTrace);
+                        errorNessage = String.Format(errorNessage, claimsProviderName, customMessage, ex.GetType().Name, ex.Message);
                     }
                 }
                 WriteTrace(category, TraceSeverity.Unexpected, errorNessage);
@@ -148,23 +159,53 @@ namespace Yvand.EntraClaimsProvider
         {
             get
             {
-                var LogSvc = SPDiagnosticsServiceBase.GetLocal<Logger>();
-                // if the Logging Service is registered, just return it.
-                if (LogSvc != null)
+                if (_Local != null)
                 {
-                    return LogSvc;
+                    return _Local;
                 }
 
-                Logger svc = null;
                 SPSecurity.RunWithElevatedPrivileges(delegate ()
                 {
-                    // otherwise instantiate and register the new instance, which requires farm administrator privileges
-                    svc = new Logger();
+                    try
+                    {
+                        // SPContext.Current can be null in some processes like PowerShell.exe
+                        if (SPContext.Current != null)
+                        {
+                            SPContext.Current.Web.AllowUnsafeUpdates = true;
+                        }
+                        // This call may try to update the persisted object, so AllowUnsafeUpdates must be set before
+                        _Local = SPDiagnosticsServiceBase.GetLocal<Logger>();
+                    }
+                    catch (SPDuplicateObjectException)
+                    {
+                        // This exception may happen for no reason that I can understand. Calling Unregister() does cleanly remove the persisted object for class Logger.
+                        // And a new persisted object will be recreated when calling new Logger()
+                        Logger.Unregister();
+                    }
+                    catch(System.Security.SecurityException)
+                    {
+                        // Even the application pool account may get an access denied while calling SPDiagnosticsServiceBase.GetLocal<Logger>();
+                    }
+
+                    // if the Logging Service is registered, just return it.
+                    if (_Local != null)
+                    {
+                        return;
+                    }
+
+                    // otherwise instantiate the new instance, which the application pool account can do
+                    _Local = new Logger();
                     //svc.Update();
                 });
-                return svc;
+                // SPContext.Current can be null in some processes like PowerShell.exe
+                if (SPContext.Current != null)
+                {
+                    SPContext.Current.Web.AllowUnsafeUpdates = false;
+                }
+                return _Local;
             }
         }
+        private static Logger _Local;
 
         public Logger() : base(DiagnosticsAreaName, SPFarm.Local) { }
         public Logger(string name, SPFarm farm) : base(name, farm) { }
@@ -222,6 +263,8 @@ namespace Yvand.EntraClaimsProvider
                         CreateCategory(TraceCategory.Rehydration),
                         CreateCategory(TraceCategory.Debug),
                         CreateCategory(TraceCategory.Custom),
+                        CreateCategory(TraceCategory.AzureIdentity),
+                        CreateCategory(TraceCategory.GraphRequests),
                     }
                 );
             }

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Utils.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Utils.cs
@@ -2,6 +2,7 @@
 using Microsoft.SharePoint.Administration.Claims;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Reflection;
 using Yvand.EntraClaimsProvider.Configuration;
@@ -112,6 +113,65 @@ namespace Yvand.EntraClaimsProvider
                 field.SetValue(target, field.GetValue(source));
             }
             return target;
+        }
+
+        public static EventLevel TraceSeverityToEventLevel(TraceSeverity level)
+        {
+            EventLevel retLevel;
+            switch (level)
+            {
+                case TraceSeverity.Unexpected:
+                    retLevel = EventLevel.Critical;
+                    break;
+
+                case TraceSeverity.High:
+                    retLevel = EventLevel.Error;
+                    break;
+
+                case TraceSeverity.Medium:
+                    retLevel = EventLevel.Warning;
+                    break;
+
+                case TraceSeverity.VerboseEx:
+                case TraceSeverity.Verbose:
+                    retLevel = EventLevel.Informational;
+                    break;
+
+                default:
+                    retLevel = EventLevel.Warning;
+                    break;
+            }
+            return retLevel;
+        }
+
+        public static TraceSeverity EventLogToTraceSeverity(EventLevel level)
+        {
+            TraceSeverity retLevel;
+            switch (level)
+            {
+                case EventLevel.Critical:
+                    retLevel = TraceSeverity.Unexpected;
+                    break;
+
+                case EventLevel.Error:
+                    retLevel = TraceSeverity.High;
+                    break;
+
+                case EventLevel.Warning:
+                    retLevel = TraceSeverity.Medium;
+                    break;
+
+                case EventLevel.Informational:
+                case EventLevel.Verbose:
+                    // Set to VerboseEx instead of Verbose, because it generates very noisy messages
+                    retLevel = TraceSeverity.VerboseEx;
+                    break;
+
+                default:
+                    retLevel = TraceSeverity.High;
+                    break;
+            }
+            return retLevel;
         }
     }
 }

--- a/assembly-bindings.config
+++ b/assembly-bindings.config
@@ -14,17 +14,25 @@ The content of this file may change for each version of EntraCP, make sure to us
         <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
         <bindingRedirect oldVersion="1.5.0.0-1.6.0.0" newVersion="1.6.1.0"/>
     </dependentAssembly>
-	<dependentAssembly>
+    <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
         <bindingRedirect oldVersion="6.0.0.0" newVersion="6.0.0.1"/>
     </dependentAssembly>
-	<dependentAssembly>
+    <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
         <bindingRedirect oldVersion="6.22.0.0" newVersion="7.0.3.0"/>
     </dependentAssembly>
-	<dependentAssembly>
+    <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
         <bindingRedirect oldVersion="4.0.1.2" newVersion="6.0.0.0"/>
+    </dependentAssembly>
+    <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="4.0.1.1" newVersion="4.0.1.2"/>
+    </dependentAssembly>
+    <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="4.0.4.1" newVersion="6.0.0.0"/>
     </dependentAssembly>
 </assemblyBinding>
 </runtime>

--- a/assembly-bindings.config
+++ b/assembly-bindings.config
@@ -11,28 +11,20 @@ The content of this file may change for each version of EntraCP, make sure to us
 <runtime>
 <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
     <dependentAssembly>
-        <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral"/>
-        <bindingRedirect oldVersion="1.33.0.0" newVersion="1.35.0.0"/>
+        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="1.5.0.0-1.6.0.0" newVersion="1.6.1.0"/>
     </dependentAssembly>
-    <dependentAssembly>
+	<dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
         <bindingRedirect oldVersion="6.0.0.0" newVersion="6.0.0.1"/>
     </dependentAssembly>
-    <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="1.0.1.0-1.3.0.0" newVersion="1.3.1.0"/>
-    </dependentAssembly>
-    <dependentAssembly>
+	<dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="6.22.0.0" newVersion="6.32.2.0"/>
+        <bindingRedirect oldVersion="6.22.0.0" newVersion="7.0.3.0"/>
     </dependentAssembly>
-    <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="4.0.1.1" newVersion="4.0.1.2"/>
-    </dependentAssembly>
-    <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="4.0.4.1" newVersion="6.0.0.0"/>
+	<dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="4.0.1.2" newVersion="6.0.0.0"/>
     </dependentAssembly>
 </assemblyBinding>
 </runtime>


### PR DESCRIPTION
## Changelog

* Fix a bug causing a hang on the web application, when using the check permissions feature to verify the permissions of a trusted user
* SharePoint 2016: The new minimum build version required to run EntraCP is 16.0.4483.1001 - January 2017 cumulative update
* Improve the management of tenant credentials, including new helpers to renew the client secret of certificate using PowerShell
* Improve page TroubleshootEntraCP.aspx
* Add a mechanism to use custom settings instead of settings from the persisted objects
* Fix issues causing logging to not be actually written in SharePoint logs
* Add logging categories "Azure Identity" and "Graph Requests"
* Improve the readability of the errors recorded in the log
* Better verify the responses from Graph, to avoid causing additional exceptions if an error already happened
* Bump dependencies