### PR TITLE
move class Logger and its deps to their own namespace

### DIFF
--- a/Yvand.EntraCP/Features/Yvand.EntraCP/Yvand.EntraCP.EventReceiver.cs
+++ b/Yvand.EntraCP/Features/Yvand.EntraCP/Yvand.EntraCP.EventReceiver.cs
@@ -3,7 +3,7 @@ using Microsoft.SharePoint.Administration;
 using Microsoft.SharePoint.Administration.Claims;
 using System;
 using System.Runtime.InteropServices;
-using Yvand.EntraClaimsProvider.Configuration;
+using Yvand.EntraClaimsProvider.Logging;
 
 namespace Yvand.EntraClaimsProvider
 {

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx.cs
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Graph.Models;
 using Microsoft.Identity.Client;
-using Microsoft.SharePoint;
 using Microsoft.SharePoint.Administration;
 using Microsoft.SharePoint.Utilities;
 using Microsoft.SharePoint.WebControls;
@@ -16,6 +15,8 @@ using System.Threading.Tasks;
 using System.Web.UI.HtmlControls;
 using System.Web.UI.WebControls;
 using Yvand.EntraClaimsProvider.Configuration;
+using Yvand.EntraClaimsProvider.Logging;
+using Logger = Yvand.EntraClaimsProvider.Logging.Logger;
 
 namespace Yvand.EntraClaimsProvider.Administration
 {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Administration/EntraCPUserControl.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Administration/EntraCPUserControl.cs
@@ -5,6 +5,7 @@ using Microsoft.SharePoint.Utilities;
 using System;
 using System.Web.UI;
 using Yvand.EntraClaimsProvider.Configuration;
+using Yvand.EntraClaimsProvider.Logging;
 
 namespace Yvand.EntraClaimsProvider.Administration
 {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -8,6 +8,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Web;
+using Yvand.EntraClaimsProvider.Logging;
+using Logger = Yvand.EntraClaimsProvider.Logging.Logger;
 using WIF4_5 = System.Security.Claims;
 
 namespace Yvand.EntraClaimsProvider.Configuration

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
+using Yvand.EntraClaimsProvider.Logging;
 
 namespace Yvand.EntraClaimsProvider.Configuration
 {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
@@ -3,8 +3,6 @@ using Azure.Core.Pipeline;
 using Azure.Identity;
 using Microsoft.Graph;
 using Microsoft.Identity.Client;
-using Microsoft.Kiota.Http.HttpClientLibrary.Middleware;
-using Microsoft.Kiota.Http.HttpClientLibrary.Middleware.Options;
 using Microsoft.SharePoint.Administration;
 using System;
 using System.Collections.Generic;
@@ -12,11 +10,11 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Reflection;
-using System.Runtime.ConstrainedExecution;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Yvand.EntraClaimsProvider.Logging;
+using Logger = Yvand.EntraClaimsProvider.Logging.Logger;
 
 namespace Yvand.EntraClaimsProvider.Configuration
 {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraCP.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraCP.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Yvand.EntraClaimsProvider.Configuration;
+using Yvand.EntraClaimsProvider.Logging;
 using WIF4_5 = System.Security.Claims;
 
 namespace Yvand.EntraClaimsProvider

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
@@ -15,9 +15,10 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using Yvand.EntraClaimsProvider.Configuration;
+using Yvand.EntraClaimsProvider.Logging;
+using Logger = Yvand.EntraClaimsProvider.Logging.Logger;
 
 namespace Yvand.EntraClaimsProvider
 {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/GraphRequestsLogging.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/GraphRequestsLogging.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Yvand.EntraClaimsProvider.Logging;
 
 namespace Yvand.EntraClaimsProvider
 {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Logger.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Logger.cs
@@ -5,10 +5,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
 
-namespace Yvand.EntraClaimsProvider
+namespace Yvand.EntraClaimsProvider.Logging
 {
     public enum TraceCategory
     {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Utils.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Utils.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Reflection;
 using Yvand.EntraClaimsProvider.Configuration;
+using Yvand.EntraClaimsProvider.Logging;
 
 namespace Yvand.EntraClaimsProvider
 {


### PR DESCRIPTION
This is necessary to clean the issues related to class Logger, introduced in EntraCP v23.0