### PR TITLE
Publish EntraCP v25.0

### DIFF
--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -2,7 +2,7 @@ name: Publish nightly release
 on: workflow_dispatch
 jobs:
   call-workflow-publish-nightly-release:
-    uses: Yvand/AzureCP/.github/workflows/reusable-build-publish-release.yml@master
+    uses: Yvand/EntraCP/.github/workflows/reusable-build-publish-release.yml@master
     with:
       project-name: ${{ vars.PROJECT_NAME }}
       version-major-minor: ${{ vars.VERSION_MAJOR_MINOR }}

--- a/.github/workflows/publish-production-release.yml
+++ b/.github/workflows/publish-production-release.yml
@@ -2,7 +2,7 @@ name: Publish production release
 on: workflow_dispatch
 jobs:
   call-workflow-publish-nightly-release:
-    uses: Yvand/AzureCP/.github/workflows/reusable-build-publish-release.yml@master
+    uses: Yvand/EntraCP/.github/workflows/reusable-build-publish-release.yml@master
     with:
       project-name: ${{ vars.PROJECT_NAME }}
       version-major-minor: ${{ vars.VERSION_MAJOR_MINOR }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   call-workflow-prepare-dtl-env:
-    uses: Yvand/AzureCP/.github/workflows/reusable-prepare-dtl-env.yml@master
+    uses: Yvand/EntraCP/.github/workflows/reusable-prepare-dtl-env.yml@master
     with:
       project-name: ${{ vars.PROJECT_NAME }}
       sharepoint-versions: ${{ inputs.sharepoint_versions }}

--- a/.github/workflows/verify-prs-and-commits.yml
+++ b/.github/workflows/verify-prs-and-commits.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   call-build:
-    uses: Yvand/AzureCP/.github/workflows/reusable-build.yml@master
+    uses: Yvand/EntraCP/.github/workflows/reusable-build.yml@master
     with:
       project-name: ${{ vars.PROJECT_NAME }}
       version-major-minor: ${{ vars.VERSION_MAJOR_MINOR }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for ~~AzureCP~~ EntraCP
 
+## Unreleased
+
+* New feature: It is now possible to configure EntraCP, to return only users that are members of some Entra groups, configured by the administrator - https://github.com/Yvand/EntraCP/pull/243
+
 ## EntraCP v24.0.20240318.32 enhancements & bug-fixes - Published in March 18, 2024
 
 * Fix "Edit" links fail to work on the "Claim types configuration" page - https://github.com/Yvand/EntraCP/pull/220

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update the global configuration page to give the possibility to update the credentials of tenants already registered - https://github.com/Yvand/EntraCP/pull/248
+* Fix an issue where tenant credentials could not be changed from a client certificate to a client secret - https://github.com/Yvand/EntraCP/pull/248
+* Prompt user for confirmation before actually deleting a tenant - https://github.com/Yvand/EntraCP/pull/248
 * New feature: It is now possible to configure EntraCP, to return only users that are members of some Entra groups, configured by the administrator - https://github.com/Yvand/EntraCP/pull/243
 * Fix the connection to Microsoft Graph not working when the tenant is hosted in a national cloud
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * New feature: It is now possible to configure EntraCP, to return only users that are members of some Entra groups, configured by the administrator - https://github.com/Yvand/EntraCP/pull/243
+* Fix the connection to Microsoft Graph not working when the tenant is hosted in a national cloud
 
 ## EntraCP v24.0.20240318.32 enhancements & bug-fixes - Published in March 18, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Prompt user for confirmation before actually deleting a tenant - https://github.com/Yvand/EntraCP/pull/248
 * New feature: It is now possible to configure EntraCP, to return only users that are members of some Entra groups, configured by the administrator - https://github.com/Yvand/EntraCP/pull/243
 * Fix the connection to Microsoft Graph not working when the tenant is hosted in a national cloud
+* Update Azure.Identity from 1.10.4 to 1.11.2
+* Update Microsoft.Graph from 5.44.0 to 5.49.0
 
 ## EntraCP v24.0.20240318.32 enhancements & bug-fixes - Published in March 18, 2024
 

--- a/Yvand.EntraCP.Tests/BasicConfigurationTests.cs
+++ b/Yvand.EntraCP.Tests/BasicConfigurationTests.cs
@@ -21,26 +21,26 @@ namespace Yvand.EntraClaimsProvider.Tests
         }
 
         [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true })]
-        public void TestAllEntraIDGroups(EntraIdTestGroup group)
+        public void TestAllTestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
         [Test]
-        public void TestSomeEntraIDGroups([Random(0, UnitTestsHelper.TotalNumberOfGroupsInSource - 1, 5)] int idx)
+        public void TestRandomTestGroups([Random(0, UnitTestsHelper.TestGroupsCount - 1, 5)] int idx)
         {
             EntraIdTestGroup group = EntraIdTestGroupsSource.Groups[idx];
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
         [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
-        public void TestAllEntraIDUsers(EntraIdTestUser user)
+        public void TestAllTestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
         }
 
         [Test]
-        public void TestSomeEntraIDUsers([Random(0, UnitTestsHelper.TotalNumberOfUsersInSource - 1, 5)] int idx)
+        public void TestRandomTestUsers([Random(0, UnitTestsHelper.TestUsersCount - 1, 5)] int idx)
         {
             var user = EntraIdTestUsersSource.Users[idx];
             base.TestSearchAndValidateForEntraIDUser(user);
@@ -48,12 +48,20 @@ namespace Yvand.EntraClaimsProvider.Tests
 
         [Test]
         [Repeat(5)]
-        public override void TestAugmentationForUsersMembersOfAllGroups()
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
         {
-            base.TestAugmentationForUsersMembersOfAllGroups();
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
 
 #if DEBUG
+        [TestCase("testEntraCPUser_001")]
+        [TestCase("testEntraCPUser_020")]
+        public void DebugTestUser(string upnPrefix)
+        {
+            EntraIdTestUser user = EntraIdTestUsersSource.Users.Find(x => x.UserPrincipalName.StartsWith(upnPrefix));
+            base.TestSearchAndValidateForEntraIDUser(user);
+        }
+
         [TestCase(@"testentracp", 30, "")]
         public void DebugSearchManual(string inputValue, int expectedResultCount, string expectedEntityClaimValue)
         {

--- a/Yvand.EntraCP.Tests/BypassDirectoryTests.cs
+++ b/Yvand.EntraCP.Tests/BypassDirectoryTests.cs
@@ -91,9 +91,9 @@ namespace Yvand.EntraClaimsProvider.Tests
 
         [Test]
         [Repeat(5)]
-        public override void TestAugmentationForUsersMembersOfAllGroups()
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
         {
-            base.TestAugmentationForUsersMembersOfAllGroups();
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
     }
 }

--- a/Yvand.EntraCP.Tests/ClaimsProviderTestsBase.cs
+++ b/Yvand.EntraCP.Tests/ClaimsProviderTestsBase.cs
@@ -59,7 +59,7 @@ namespace Yvand.EntraClaimsProvider.Tests
                 {
                     if (_GroupsWhichUsersMustBeMemberOfAny != null) { return _GroupsWhichUsersMustBeMemberOfAny; }
                     _GroupsWhichUsersMustBeMemberOfAny = new List<EntraIdTestGroupSettings>();
-                    string groupsWhichUsersMustBeMemberOfAny = Settings.GroupsWhichUsersMustBeMemberOfAny;
+                    string groupsWhichUsersMustBeMemberOfAny = Settings.RestrictSearchableUsersByGroups;
                     if (!String.IsNullOrWhiteSpace(groupsWhichUsersMustBeMemberOfAny))
                     {
                         string[] groupIds = groupsWhichUsersMustBeMemberOfAny.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
@@ -152,18 +152,18 @@ namespace Yvand.EntraClaimsProvider.Tests
             }
             else
             {
-                if (!String.IsNullOrWhiteSpace(Settings.GroupsWhichUsersMustBeMemberOfAny))
+                if (!String.IsNullOrWhiteSpace(Settings.RestrictSearchableUsersByGroups))
                 {
                     lock (_LockVerifyIfCurrentUserShouldBeFound) // TODO: understand why this lock is necessary
                     {
-                        // Test 1: Does Settings.GroupsWhichUsersMustBeMemberOfAny contain any group where all test users are members?
+                        // Test 1: Does Settings.RestrictSearchableUsersByGroups contain any group where all test users are members?
                         bool groupWithAllTestUsersAreMembersFound = false;
                         foreach (var groupSettings in GroupsWhichUsersMustBeMemberOfAny)
                         {
                             if (groupSettings.AllTestUsersAreMembers)
                             {
                                 groupWithAllTestUsersAreMembersFound = true;
-                                Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] User \"{entity.UserPrincipalName}\" may be found because Settings.GroupsWhichUsersMustBeMemberOfAny contains group: \"{groupSettings.DisplayName}\" with AllTestUsersAreMembers {groupSettings.AllTestUsersAreMembers}.");
+                                Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] User \"{entity.UserPrincipalName}\" may be found because Settings.RestrictSearchableUsersByGroups contains group: \"{groupSettings.DisplayName}\" with AllTestUsersAreMembers {groupSettings.AllTestUsersAreMembers}.");
                                 break;  // No need to change shouldValidate, which is true by default, or process other groups
                             }
                         }
@@ -178,14 +178,14 @@ namespace Yvand.EntraClaimsProvider.Tests
                             {
                                 shouldValidate = false;
                                 expectedCount = 0;
-                                Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] User \"{entity.UserPrincipalName}\" should not be found because it has IsMemberOfAllGroups {userSettings.IsMemberOfAllGroups} and no group set in Settings.GroupsWhichUsersMustBeMemberOfAny has AllTestUsersAreMembers set to true.");
+                                Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] User \"{entity.UserPrincipalName}\" should not be found because it has IsMemberOfAllGroups {userSettings.IsMemberOfAllGroups} and no group set in Settings.RestrictSearchableUsersByGroups has AllTestUsersAreMembers set to true.");
                             }
                         }
                     }
                 }
                 else
                 {
-                    Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] Property Settings.GroupsWhichUsersMustBeMemberOfAny IsNullOrWhiteSpace.");
+                    Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] Property Settings.RestrictSearchableUsersByGroups IsNullOrWhiteSpace.");
                 }
 
                 // If shouldValidate is false, user should not be found anyway so no need to do additional checks

--- a/Yvand.EntraCP.Tests/ClaimsProviderTestsBase.cs
+++ b/Yvand.EntraCP.Tests/ClaimsProviderTestsBase.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Security.Claims;
 using System.Text;
@@ -48,6 +47,35 @@ namespace Yvand.EntraClaimsProvider.Tests
 
         protected EntraIDProviderSettings Settings = new EntraIDProviderSettings();
 
+        private object _LockVerifyIfCurrentUserShouldBeFound = new object();
+        private object _LockInitGroupsWhichUsersMustBeMemberOfAny = new object();
+        private List<EntraIdTestGroupSettings> _GroupsWhichUsersMustBeMemberOfAny;
+        protected List<EntraIdTestGroupSettings> GroupsWhichUsersMustBeMemberOfAny
+        {
+            get
+            {
+                if (_GroupsWhichUsersMustBeMemberOfAny != null) { return _GroupsWhichUsersMustBeMemberOfAny; }
+                lock (_LockInitGroupsWhichUsersMustBeMemberOfAny)
+                {
+                    if (_GroupsWhichUsersMustBeMemberOfAny != null) { return _GroupsWhichUsersMustBeMemberOfAny; }
+                    _GroupsWhichUsersMustBeMemberOfAny = new List<EntraIdTestGroupSettings>();
+                    string groupsWhichUsersMustBeMemberOfAny = Settings.GroupsWhichUsersMustBeMemberOfAny;
+                    if (!String.IsNullOrWhiteSpace(groupsWhichUsersMustBeMemberOfAny))
+                    {
+                        string[] groupIds = groupsWhichUsersMustBeMemberOfAny.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                        foreach (string groupId in groupIds)
+                        {
+                            EntraIdTestGroupSettings groupSettings = EntraIdTestGroupsSource.GroupsSettings.FirstOrDefault(x => x.Id == groupId);
+                            if (groupSettings == null) { groupSettings = new EntraIdTestGroupSettings(); }
+                            _GroupsWhichUsersMustBeMemberOfAny.Add(groupSettings);
+                        }
+                    }
+                    return _GroupsWhichUsersMustBeMemberOfAny;
+                }
+            }
+        }
+
+
         /// <summary>
         /// Initialize settings
         /// </summary>
@@ -62,10 +90,8 @@ namespace Yvand.EntraClaimsProvider.Tests
             Settings.Timeout = 99999;
 #endif
 
-            string json = File.ReadAllText(UnitTestsHelper.AzureTenantsJsonFile);
-            List<EntraIDTenant> azureTenants = JsonConvert.DeserializeObject<List<EntraIDTenant>>(json);
-            Settings.EntraIDTenants = azureTenants;
-            foreach (EntraIDTenant tenant in azureTenants)
+            Settings.EntraIDTenants = new List<EntraIDTenant> { UnitTestsHelper.TenantConnection };
+            foreach (EntraIDTenant tenant in Settings.EntraIDTenants)
             {
                 tenant.ExcludeMemberUsers = ExcludeMemberUsers;
                 tenant.ExcludeGuestUsers = ExcludeGuestUsers;
@@ -126,37 +152,91 @@ namespace Yvand.EntraClaimsProvider.Tests
             }
             else
             {
-                if (entity.UserType == UserType.Member)
+                if (!String.IsNullOrWhiteSpace(Settings.GroupsWhichUsersMustBeMemberOfAny))
                 {
-                    claimValue = Settings.ClaimTypes.UserIdentifierConfig.EntityProperty == Configuration.DirectoryObjectProperty.UserPrincipalName ?
-                        entity.UserPrincipalName :
-                        entity.Mail;
-                    expectedCount = ExcludeMemberUsers ? 0 : 1;
-                    shouldValidate = !ExcludeMemberUsers;
+                    lock (_LockVerifyIfCurrentUserShouldBeFound) // TODO: understand why this lock is necessary
+                    {
+                        // Test 1: Does Settings.GroupsWhichUsersMustBeMemberOfAny contain any group where all test users are members?
+                        bool groupWithAllTestUsersAreMembersFound = false;
+                        foreach (var groupSettings in GroupsWhichUsersMustBeMemberOfAny)
+                        {
+                            if (groupSettings.AllTestUsersAreMembers)
+                            {
+                                groupWithAllTestUsersAreMembersFound = true;
+                                Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] User \"{entity.UserPrincipalName}\" may be found because Settings.GroupsWhichUsersMustBeMemberOfAny contains group: \"{groupSettings.DisplayName}\" with AllTestUsersAreMembers {groupSettings.AllTestUsersAreMembers}.");
+                                break;  // No need to change shouldValidate, which is true by default, or process other groups
+                            }
+                        }
+
+                        // Test 2: If test 1 is false, is current entity member of all the test groups?
+                        if (!groupWithAllTestUsersAreMembersFound)
+                        {
+
+                            EntraIdTestUserSettings userSettings = EntraIdTestUsersSource.UsersWithSpecificSettings.FirstOrDefault(x => String.Equals(x.UserPrincipalName, entity.UserPrincipalName, StringComparison.InvariantCultureIgnoreCase));
+                            if (userSettings == null) { userSettings = new EntraIdTestUserSettings(); }
+                            if (!userSettings.IsMemberOfAllGroups)
+                            {
+                                shouldValidate = false;
+                                expectedCount = 0;
+                                Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] User \"{entity.UserPrincipalName}\" should not be found because it has IsMemberOfAllGroups {userSettings.IsMemberOfAllGroups} and no group set in Settings.GroupsWhichUsersMustBeMemberOfAny has AllTestUsersAreMembers set to true.");
+                            }
+                        }
+                    }
                 }
                 else
                 {
-                    claimValue = Settings.ClaimTypes.UserIdentifierConfig.DirectoryObjectPropertyForGuestUsers == Configuration.DirectoryObjectProperty.UserPrincipalName ?
-                        entity.UserPrincipalName :
-                        entity.Mail;
-                    expectedCount = ExcludeGuestUsers ? 0 : 1;
-                    shouldValidate = !ExcludeGuestUsers;
+                    Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] Property Settings.GroupsWhichUsersMustBeMemberOfAny IsNullOrWhiteSpace.");
+                }
+
+                // If shouldValidate is false, user should not be found anyway so no need to do additional checks
+                if (shouldValidate)
+                {
+                    if (entity.UserType == UserType.Member)
+                    {
+                        claimValue = Settings.ClaimTypes.UserIdentifierConfig.EntityProperty == Configuration.DirectoryObjectProperty.UserPrincipalName ?
+                            entity.UserPrincipalName :
+                            entity.Mail;
+                        expectedCount = ExcludeMemberUsers ? 0 : 1;
+                        shouldValidate = !ExcludeMemberUsers;
+                    }
+                    else
+                    {
+                        claimValue = Settings.ClaimTypes.UserIdentifierConfig.DirectoryObjectPropertyForGuestUsers == Configuration.DirectoryObjectProperty.UserPrincipalName ?
+                            entity.UserPrincipalName :
+                            entity.Mail;
+                        expectedCount = ExcludeGuestUsers ? 0 : 1;
+                        shouldValidate = !ExcludeGuestUsers;
+                    }
                 }
             }
             TestSearchOperation(inputValue, expectedCount, claimValue);
             TestValidationOperation(UserIdentifierClaimType, claimValue, shouldValidate);
         }
 
-        public virtual void TestAugmentationForUsersMembersOfAllGroups()
+        /// <summary>
+        /// Gold users are the test users who are members of all the test groups
+        /// </summary>
+        public virtual void TestAugmentationOfGoldUsersAgainstRandomGroups()
         {
             Random rnd = new Random();
-            int randomIdx = rnd.Next(0, UnitTestsHelper.TotalNumberOfGroupsInSource - 1);
-            var anyGroup = EntraIdTestGroupsSource.Groups[randomIdx];
-            bool shouldBeMember = Settings.FilterSecurityEnabledGroupsOnly && !anyGroup.SecurityEnabled ? false : true;
-            foreach (string userAccountName in UnitTestsHelper.UsersMembersOfAllGroups)
+            int randomIdx = rnd.Next(0, UnitTestsHelper.TestGroupsCount - 1);
+            Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] TestAugmentationOfGoldUsersAgainstRandomGroups: Get group in EntraIdTestGroupsSource.Groups at index {randomIdx}.");
+            EntraIdTestGroup randomGroup = null;
+            try
             {
-                string userPrincipalName = EntraIdTestUsersSource.Users.First(x => x.UserPrincipalName.StartsWith(userAccountName, StringComparison.InvariantCultureIgnoreCase)).UserPrincipalName;
-                TestAugmentationOperation(userPrincipalName, shouldBeMember, anyGroup.Id);
+                randomGroup = EntraIdTestGroupsSource.Groups[randomIdx];
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                string errorMessage = $"{DateTime.Now:s} [{this.GetType().Name}] TestAugmentationOfGoldUsersAgainstRandomGroups: Could not get group in EntraIdTestGroupsSource.Groups at index {randomIdx}. EntraIdTestGroupsSource.Groups has {EntraIdTestGroupsSource.Groups.Count} items.";
+                Trace.TraceError(errorMessage);
+                throw new ArgumentOutOfRangeException(errorMessage);
+            }
+            bool shouldBeMember = Settings.FilterSecurityEnabledGroupsOnly && !randomGroup.SecurityEnabled ? false : true;
+
+            foreach (string userPrincipalName in EntraIdTestUsersSource.UsersWithSpecificSettings.Where(x => x.IsMemberOfAllGroups).Select(x => x.UserPrincipalName))
+            {
+                TestAugmentationOperation(userPrincipalName, shouldBeMember, randomGroup.Id);
             }
         }
 

--- a/Yvand.EntraCP.Tests/ExcludeAUserTypeTests.cs
+++ b/Yvand.EntraCP.Tests/ExcludeAUserTypeTests.cs
@@ -35,9 +35,9 @@ namespace Yvand.EntraClaimsProvider.Tests
 
         [Test]
         [Repeat(5)]
-        public override void TestAugmentationForUsersMembersOfAllGroups()
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
         {
-            base.TestAugmentationForUsersMembersOfAllGroups();
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
     }
 
@@ -74,9 +74,9 @@ namespace Yvand.EntraClaimsProvider.Tests
 
         [Test]
         [Repeat(5)]
-        public override void TestAugmentationForUsersMembersOfAllGroups()
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
         {
-            base.TestAugmentationForUsersMembersOfAllGroups();
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
     }
 
@@ -113,9 +113,9 @@ namespace Yvand.EntraClaimsProvider.Tests
 
         [Test]
         [Repeat(5)]
-        public override void TestAugmentationForUsersMembersOfAllGroups()
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
         {
-            base.TestAugmentationForUsersMembersOfAllGroups();
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
     }
 }

--- a/Yvand.EntraCP.Tests/FilterUsersBasedOnGroupsTests.cs
+++ b/Yvand.EntraCP.Tests/FilterUsersBasedOnGroupsTests.cs
@@ -12,7 +12,7 @@ namespace Yvand.EntraClaimsProvider.Tests
         public override void InitializeSettings()
         {
             base.InitializeSettings();
-            Settings.GroupsWhichUsersMustBeMemberOfAny = EntraIdTestGroupsSource.ASecurityEnabledGroup.Id;
+            Settings.RestrictSearchableUsersByGroups = EntraIdTestGroupsSource.ASecurityEnabledGroup.Id;
             base.ApplySettings();
         }
 
@@ -47,7 +47,7 @@ namespace Yvand.EntraClaimsProvider.Tests
         {
             base.InitializeSettings();
 
-            // Pick the Id of 18 (max possible) random groups, and it in property GroupsWhichUsersMustBeMemberOfAny
+            // Pick the Id of 18 (max possible) random groups, and it in property RestrictSearchableUsersByGroups
             List<string> groupIdsList = new List<string>();
             Random rnd = new Random();
             for (int groupsCount = 1; groupsCount <= 18; groupsCount++)
@@ -55,8 +55,8 @@ namespace Yvand.EntraClaimsProvider.Tests
                 int randomIdx = rnd.Next(0, UnitTestsHelper.TestGroupsCount - 1);
                 groupIdsList.Add(EntraIdTestGroupsSource.Groups[randomIdx].Id);
             }
-            Settings.GroupsWhichUsersMustBeMemberOfAny = String.Join(",", groupIdsList);
-            Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] Set property GroupsWhichUsersMustBeMemberOfAny: \"{Settings.GroupsWhichUsersMustBeMemberOfAny}\".");
+            Settings.RestrictSearchableUsersByGroups = String.Join(",", groupIdsList);
+            Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] Set property RestrictSearchableUsersByGroups: \"{Settings.RestrictSearchableUsersByGroups}\".");
 
             base.ApplySettings();
         }
@@ -92,10 +92,10 @@ namespace Yvand.EntraClaimsProvider.Tests
         public override void InitializeSettings()
         {
             base.InitializeSettings();
-            Settings.GroupsWhichUsersMustBeMemberOfAny = "dbcdaf68-5949-4a15-b2f8-f385b41a9fca,72860e7b-93d5-46f7-ab56-480112f76548,461e8865-0f39-4199-86c6-0c8e25ad57ea,33780f8d-8345-4402-bc6a-d9c7e5d40d36,2c6b2fde-4f89-417a-9d8c-5e459e1520cf,7059e0ae-0cbc-4f4d-9d87-fef7289a7f50,dbcdaf68-5949-4a15-b2f8-f385b41a9fca,3cc758d6-7198-470f-878a-e5cd41a35e02,b05ddc92-b639-4ba2-95b3-9fdbc1bff2f2,40a7290c-9b67-4b7c-98ff-0c9871544423,71aa60d9-c4d1-4eaf-b398-3099b12afd88,0f51d30e-e03c-44ea-8d13-df0ca0df7a16,0f51d30e-e03c-44ea-8d13-df0ca0df7a16,982369ed-e88f-4b21-9b89-29067a0fa326,a40d2ded-2ab0-463f-b000-b3351ca6341d,ce5a4725-e719-4c2d-89bc-1c356facde99,de600b84-29aa-470c-b6ca-1459591728fb,152456d1-73a0-46d6-ac02-0403f2b5593e";
-            Settings.GroupsWhichUsersMustBeMemberOfAny = "db41d655-d796-43fb-9e23-351ee8b5bdb0,461e8865-0f39-4199-86c6-0c8e25ad57ea,21dd6198-c447-48dd-9ea8-347f804c4dec,dcf1e533-6d55-4b00-9788-f0d81e287c8a,21dd6198-c447-48dd-9ea8-347f804c4dec,719006f9-8eb0-48fd-8f95-556f07b0123b,d6896744-f16b-4802-9f13-0e2c9fa06274,dcf1e533-6d55-4b00-9788-f0d81e287c8a,2ae8ff19-0e4f-45cc-98ea-84f1c53e60f2,bea2607f-513a-4324-a6a1-620ee1c0ced4,bcd82b83-97c5-4c1c-9cce-58643a286298,34fe3af4-7ed9-4b5e-a64e-c0b230d5dfb4,136f71a2-c57c-4a3f-8aec-4d694e442b87,dbf5a5c3-5f51-42d6-a519-258c76960f75,33780f8d-8345-4402-bc6a-d9c7e5d40d36,a40d2ded-2ab0-463f-b000-b3351ca6341d,21dd6198-c447-48dd-9ea8-347f804c4dec,34fe3af4-7ed9-4b5e-a64e-c0b230d5dfb4";
-            Settings.GroupsWhichUsersMustBeMemberOfAny = "71aa60d9-c4d1-4eaf-b398-3099b12afd88,56e7a2e2-f565-450e-94cd-0d7d314217d1,c9a94341-89b5-4109-a501-2a14027b5bf0,8962bad6-ceca-43ff-a4be-9258ff81af2f,36d78c5a-80f2-4f3d-8f37-3a347d000d56,152456d1-73a0-46d6-ac02-0403f2b5593e,d6896744-f16b-4802-9f13-0e2c9fa06274,de600b84-29aa-470c-b6ca-1459591728fb,d51f225f-b484-4898-b425-5d48553aad16,36d78c5a-80f2-4f3d-8f37-3a347d000d56,0f51d30e-e03c-44ea-8d13-df0ca0df7a16,1eb5e51e-0bea-40c3-9ffb-0b85dbe2f9bf,dcf1e533-6d55-4b00-9788-f0d81e287c8a,c9a94341-89b5-4109-a501-2a14027b5bf0,3cc758d6-7198-470f-878a-e5cd41a35e02,dcf1e533-6d55-4b00-9788-f0d81e287c8a,21dd6198-c447-48dd-9ea8-347f804c4dec,253fe6d4-8e07-49a1-8a74-143d265eefbe";
-            Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] Set property GroupsWhichUsersMustBeMemberOfAny: \"{Settings.GroupsWhichUsersMustBeMemberOfAny}\".");
+            Settings.RestrictSearchableUsersByGroups = "dbcdaf68-5949-4a15-b2f8-f385b41a9fca,72860e7b-93d5-46f7-ab56-480112f76548,461e8865-0f39-4199-86c6-0c8e25ad57ea,33780f8d-8345-4402-bc6a-d9c7e5d40d36,2c6b2fde-4f89-417a-9d8c-5e459e1520cf,7059e0ae-0cbc-4f4d-9d87-fef7289a7f50,dbcdaf68-5949-4a15-b2f8-f385b41a9fca,3cc758d6-7198-470f-878a-e5cd41a35e02,b05ddc92-b639-4ba2-95b3-9fdbc1bff2f2,40a7290c-9b67-4b7c-98ff-0c9871544423,71aa60d9-c4d1-4eaf-b398-3099b12afd88,0f51d30e-e03c-44ea-8d13-df0ca0df7a16,0f51d30e-e03c-44ea-8d13-df0ca0df7a16,982369ed-e88f-4b21-9b89-29067a0fa326,a40d2ded-2ab0-463f-b000-b3351ca6341d,ce5a4725-e719-4c2d-89bc-1c356facde99,de600b84-29aa-470c-b6ca-1459591728fb,152456d1-73a0-46d6-ac02-0403f2b5593e";
+            Settings.RestrictSearchableUsersByGroups = "db41d655-d796-43fb-9e23-351ee8b5bdb0,461e8865-0f39-4199-86c6-0c8e25ad57ea,21dd6198-c447-48dd-9ea8-347f804c4dec,dcf1e533-6d55-4b00-9788-f0d81e287c8a,21dd6198-c447-48dd-9ea8-347f804c4dec,719006f9-8eb0-48fd-8f95-556f07b0123b,d6896744-f16b-4802-9f13-0e2c9fa06274,dcf1e533-6d55-4b00-9788-f0d81e287c8a,2ae8ff19-0e4f-45cc-98ea-84f1c53e60f2,bea2607f-513a-4324-a6a1-620ee1c0ced4,bcd82b83-97c5-4c1c-9cce-58643a286298,34fe3af4-7ed9-4b5e-a64e-c0b230d5dfb4,136f71a2-c57c-4a3f-8aec-4d694e442b87,dbf5a5c3-5f51-42d6-a519-258c76960f75,33780f8d-8345-4402-bc6a-d9c7e5d40d36,a40d2ded-2ab0-463f-b000-b3351ca6341d,21dd6198-c447-48dd-9ea8-347f804c4dec,34fe3af4-7ed9-4b5e-a64e-c0b230d5dfb4";
+            Settings.RestrictSearchableUsersByGroups = "71aa60d9-c4d1-4eaf-b398-3099b12afd88,56e7a2e2-f565-450e-94cd-0d7d314217d1,c9a94341-89b5-4109-a501-2a14027b5bf0,8962bad6-ceca-43ff-a4be-9258ff81af2f,36d78c5a-80f2-4f3d-8f37-3a347d000d56,152456d1-73a0-46d6-ac02-0403f2b5593e,d6896744-f16b-4802-9f13-0e2c9fa06274,de600b84-29aa-470c-b6ca-1459591728fb,d51f225f-b484-4898-b425-5d48553aad16,36d78c5a-80f2-4f3d-8f37-3a347d000d56,0f51d30e-e03c-44ea-8d13-df0ca0df7a16,1eb5e51e-0bea-40c3-9ffb-0b85dbe2f9bf,dcf1e533-6d55-4b00-9788-f0d81e287c8a,c9a94341-89b5-4109-a501-2a14027b5bf0,3cc758d6-7198-470f-878a-e5cd41a35e02,dcf1e533-6d55-4b00-9788-f0d81e287c8a,21dd6198-c447-48dd-9ea8-347f804c4dec,253fe6d4-8e07-49a1-8a74-143d265eefbe";
+            Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] Set property RestrictSearchableUsersByGroups: \"{Settings.RestrictSearchableUsersByGroups}\".");
             base.ApplySettings();
         }
 

--- a/Yvand.EntraCP.Tests/FilterUsersBasedOnGroupsTests.cs
+++ b/Yvand.EntraCP.Tests/FilterUsersBasedOnGroupsTests.cs
@@ -1,0 +1,118 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Yvand.EntraClaimsProvider.Tests
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.Children)]
+    public class FilterUsersBasedOnSingleGroupTests : ClaimsProviderTestsBase
+    {
+        public override void InitializeSettings()
+        {
+            base.InitializeSettings();
+            Settings.GroupsWhichUsersMustBeMemberOfAny = EntraIdTestGroupsSource.ASecurityEnabledGroup.Id;
+            base.ApplySettings();
+        }
+
+        [Test]
+        public override void CheckSettingsTest()
+        {
+            base.CheckSettingsTest();
+        }
+
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
+        public void TestAllTestUsers(EntraIdTestUser user)
+        {
+            base.TestSearchAndValidateForEntraIDUser(user);
+        }
+
+#if DEBUG
+        [TestCase("testEntraCPUser_001")]
+        [TestCase("testEntraCPUser_020")]
+        public void DebugTestUser(string upnPrefix)
+        {
+            EntraIdTestUser user = EntraIdTestUsersSource.Users.Find(x => x.UserPrincipalName.StartsWith(upnPrefix));
+            base.TestSearchAndValidateForEntraIDUser(user);
+        }
+#endif
+    }
+
+    [TestFixture]
+    [Parallelizable(ParallelScope.Children)]
+    public class FilterUsersBasedOnMultipleGroupsTests : ClaimsProviderTestsBase
+    {
+        public override void InitializeSettings()
+        {
+            base.InitializeSettings();
+
+            // Pick the Id of 18 (max possible) random groups, and it in property GroupsWhichUsersMustBeMemberOfAny
+            List<string> groupIdsList = new List<string>();
+            Random rnd = new Random();
+            for (int groupsCount = 1; groupsCount <= 18; groupsCount++)
+            {
+                int randomIdx = rnd.Next(0, UnitTestsHelper.TestGroupsCount - 1);
+                groupIdsList.Add(EntraIdTestGroupsSource.Groups[randomIdx].Id);
+            }
+            Settings.GroupsWhichUsersMustBeMemberOfAny = String.Join(",", groupIdsList);
+            Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] Set property GroupsWhichUsersMustBeMemberOfAny: \"{Settings.GroupsWhichUsersMustBeMemberOfAny}\".");
+
+            base.ApplySettings();
+        }
+
+        [Test]
+        public override void CheckSettingsTest()
+        {
+            base.CheckSettingsTest();
+        }
+
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
+        public void TestAllTestUsers(EntraIdTestUser user)
+        {
+            base.TestSearchAndValidateForEntraIDUser(user);
+        }
+
+#if DEBUG
+        [TestCase("testEntraCPUser_001")]
+        [TestCase("testEntraCPUser_020")]
+        public void DebugTestUser(string upnPrefix)
+        {
+            EntraIdTestUser user = EntraIdTestUsersSource.Users.Find(x => x.UserPrincipalName.StartsWith(upnPrefix));
+            base.TestSearchAndValidateForEntraIDUser(user);
+        }
+#endif
+    }
+
+#if DEBUG
+    [TestFixture]
+    [Parallelizable(ParallelScope.Children)]
+    public class DebugFilterUsersBasedOnMultipleGroupsTests : ClaimsProviderTestsBase
+    {
+        public override void InitializeSettings()
+        {
+            base.InitializeSettings();
+            Settings.GroupsWhichUsersMustBeMemberOfAny = "dbcdaf68-5949-4a15-b2f8-f385b41a9fca,72860e7b-93d5-46f7-ab56-480112f76548,461e8865-0f39-4199-86c6-0c8e25ad57ea,33780f8d-8345-4402-bc6a-d9c7e5d40d36,2c6b2fde-4f89-417a-9d8c-5e459e1520cf,7059e0ae-0cbc-4f4d-9d87-fef7289a7f50,dbcdaf68-5949-4a15-b2f8-f385b41a9fca,3cc758d6-7198-470f-878a-e5cd41a35e02,b05ddc92-b639-4ba2-95b3-9fdbc1bff2f2,40a7290c-9b67-4b7c-98ff-0c9871544423,71aa60d9-c4d1-4eaf-b398-3099b12afd88,0f51d30e-e03c-44ea-8d13-df0ca0df7a16,0f51d30e-e03c-44ea-8d13-df0ca0df7a16,982369ed-e88f-4b21-9b89-29067a0fa326,a40d2ded-2ab0-463f-b000-b3351ca6341d,ce5a4725-e719-4c2d-89bc-1c356facde99,de600b84-29aa-470c-b6ca-1459591728fb,152456d1-73a0-46d6-ac02-0403f2b5593e";
+            Settings.GroupsWhichUsersMustBeMemberOfAny = "db41d655-d796-43fb-9e23-351ee8b5bdb0,461e8865-0f39-4199-86c6-0c8e25ad57ea,21dd6198-c447-48dd-9ea8-347f804c4dec,dcf1e533-6d55-4b00-9788-f0d81e287c8a,21dd6198-c447-48dd-9ea8-347f804c4dec,719006f9-8eb0-48fd-8f95-556f07b0123b,d6896744-f16b-4802-9f13-0e2c9fa06274,dcf1e533-6d55-4b00-9788-f0d81e287c8a,2ae8ff19-0e4f-45cc-98ea-84f1c53e60f2,bea2607f-513a-4324-a6a1-620ee1c0ced4,bcd82b83-97c5-4c1c-9cce-58643a286298,34fe3af4-7ed9-4b5e-a64e-c0b230d5dfb4,136f71a2-c57c-4a3f-8aec-4d694e442b87,dbf5a5c3-5f51-42d6-a519-258c76960f75,33780f8d-8345-4402-bc6a-d9c7e5d40d36,a40d2ded-2ab0-463f-b000-b3351ca6341d,21dd6198-c447-48dd-9ea8-347f804c4dec,34fe3af4-7ed9-4b5e-a64e-c0b230d5dfb4";
+            Settings.GroupsWhichUsersMustBeMemberOfAny = "71aa60d9-c4d1-4eaf-b398-3099b12afd88,56e7a2e2-f565-450e-94cd-0d7d314217d1,c9a94341-89b5-4109-a501-2a14027b5bf0,8962bad6-ceca-43ff-a4be-9258ff81af2f,36d78c5a-80f2-4f3d-8f37-3a347d000d56,152456d1-73a0-46d6-ac02-0403f2b5593e,d6896744-f16b-4802-9f13-0e2c9fa06274,de600b84-29aa-470c-b6ca-1459591728fb,d51f225f-b484-4898-b425-5d48553aad16,36d78c5a-80f2-4f3d-8f37-3a347d000d56,0f51d30e-e03c-44ea-8d13-df0ca0df7a16,1eb5e51e-0bea-40c3-9ffb-0b85dbe2f9bf,dcf1e533-6d55-4b00-9788-f0d81e287c8a,c9a94341-89b5-4109-a501-2a14027b5bf0,3cc758d6-7198-470f-878a-e5cd41a35e02,dcf1e533-6d55-4b00-9788-f0d81e287c8a,21dd6198-c447-48dd-9ea8-347f804c4dec,253fe6d4-8e07-49a1-8a74-143d265eefbe";
+            Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] Set property GroupsWhichUsersMustBeMemberOfAny: \"{Settings.GroupsWhichUsersMustBeMemberOfAny}\".");
+            base.ApplySettings();
+        }
+
+        [TestCase("testEntraCPUser_001")]
+        [TestCase("testEntraCPUser_020")]
+        public void DebugTestUser(string upnPrefix)
+        {
+            EntraIdTestUser user = EntraIdTestUsersSource.Users.Find(x => x.UserPrincipalName.StartsWith(upnPrefix));
+            base.TestSearchAndValidateForEntraIDUser(user);
+        }
+
+        [Test]
+        public void DebugGuestUser()
+        {
+            EntraIdTestUser user = EntraIdTestUsersSource.Users.Find(x => x.Mail.StartsWith("testEntraCPGuestUser_001"));
+            base.TestSearchAndValidateForEntraIDUser(user);
+        }
+    }
+#endif
+}

--- a/Yvand.EntraCP.Tests/GuestAccountsUPNTests.cs
+++ b/Yvand.EntraCP.Tests/GuestAccountsUPNTests.cs
@@ -38,9 +38,9 @@ namespace Yvand.EntraClaimsProvider.Tests
 
         [Test]
         [Repeat(5)]
-        public override void TestAugmentationForUsersMembersOfAllGroups()
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
         {
-            base.TestAugmentationForUsersMembersOfAllGroups();
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
     }
 }

--- a/Yvand.EntraCP.Tests/SecurityEnabledGroupsTests.cs
+++ b/Yvand.EntraCP.Tests/SecurityEnabledGroupsTests.cs
@@ -32,9 +32,9 @@ namespace Yvand.EntraClaimsProvider.Tests
 
         [Test]
         [Repeat(5)]
-        public override void TestAugmentationForUsersMembersOfAllGroups()
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
         {
-            base.TestAugmentationForUsersMembersOfAllGroups();
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
     }
 
@@ -65,9 +65,9 @@ namespace Yvand.EntraClaimsProvider.Tests
 
         [Test]
         [Repeat(5)]
-        public override void TestAugmentationForUsersMembersOfAllGroups()
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
         {
-            base.TestAugmentationForUsersMembersOfAllGroups();
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
     }
 }

--- a/Yvand.EntraCP.Tests/Setup/Populate-EntraIDTenant.ps1
+++ b/Yvand.EntraCP.Tests/Setup/Populate-EntraIDTenant.ps1
@@ -12,27 +12,34 @@
 Connect-MgGraph -Scopes "User.ReadWrite.All", "Group.ReadWrite.All" -UseDeviceCode
 $tenantName = (Get-MgOrganization).VerifiedDomains[0].Name
 
-$accountNamePrefix = "testEntraCPUser_"
+$memberUsersNamePrefix = "testEntraCPUser_"
+$guestUsersNamePrefix = "testEntraCPGuestUser_"
 $groupNamePrefix = "testEntraCPGroup_"
-$confirmation = Read-Host "Connected to tenant '$tenantName' and about to process users starting with '$accountNamePrefix' and groups starting with '$groupNamePrefix'. Are you sure you want to proceed? [y/n]"
+
+$confirmation = Read-Host "Connected to tenant '$tenantName' and about to process users starting with '$memberUsersNamePrefix' and groups starting with '$groupNamePrefix'. Are you sure you want to proceed? [y/n]"
 if ($confirmation -ne 'y') {
     Write-Warning -Message "Aborted."
     return
 }
 
 # Set specific attributes for some users
-$usersWithSpecificAttributes = @( 
-    @{ UserPrincipalName = "$($accountNamePrefix)001@$($tenantName)"; IsMemberOfAllGroups = $true }
-    @{ UserPrincipalName = "$($accountNamePrefix)002@$($tenantName)"; UserAttributes = @{ "GivenName" = "firstname 002" } }
-    @{ UserPrincipalName = "$($accountNamePrefix)010@$($tenantName)"; IsMemberOfAllGroups = $true }
-    @{ UserPrincipalName = "$($accountNamePrefix)011@$($tenantName)"; IsMemberOfAllGroups = $true }
-    @{ UserPrincipalName = "$($accountNamePrefix)012@$($tenantName)"; IsMemberOfAllGroups = $true }
-    @{ UserPrincipalName = "$($accountNamePrefix)013@$($tenantName)"; IsMemberOfAllGroups = $true }
-    @{ UserPrincipalName = "$($accountNamePrefix)014@$($tenantName)"; IsMemberOfAllGroups = $true }
-    @{ UserPrincipalName = "$($accountNamePrefix)015@$($tenantName)"; IsMemberOfAllGroups = $true }
+$usersWithSpecificSettings = @( 
+    @{ UserPrincipalName = "$($memberUsersNamePrefix)001@$($tenantName)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($memberUsersNamePrefix)002@$($tenantName)"; UserAttributes = @{ "GivenName" = "firstname 002" } }
+    @{ UserPrincipalName = "$($memberUsersNamePrefix)010@$($tenantName)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($memberUsersNamePrefix)011@$($tenantName)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($memberUsersNamePrefix)012@$($tenantName)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($memberUsersNamePrefix)013@$($tenantName)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($memberUsersNamePrefix)014@$($tenantName)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($memberUsersNamePrefix)015@$($tenantName)"; IsMemberOfAllGroups = $true }
 )
-
-$dtlGroupsSettings = @(
+$guestUsersList = @(
+    @{ Mail = "$($guestUsersNamePrefix)001@contoso.local"; Id = ""; UserPrincipalName = "" }
+    @{ Mail = "$($guestUsersNamePrefix)002@contoso.local"; Id = ""; UserPrincipalName = "" }
+    @{ Mail = "$($guestUsersNamePrefix)003@contoso.local"; Id = ""; UserPrincipalName = "" }
+)
+#$guestUsers = @("$($guestUsersNamePrefix)001@contoso.local", "$($guestUsersNamePrefix)002@contoso.local", "$($guestUsersNamePrefix)003@contoso.local")
+$groupsWithSpecificSettings = @(
     @{
         GroupName              = "$($groupNamePrefix)001"
         SecurityEnabled        = $false
@@ -70,7 +77,6 @@ $dtlGroupsSettings = @(
     }
 )
 
-$guestUsers = @("testEntraCPGuestUser_001@contoso.local", "testEntraCPGuestUser_002@contoso.local", "testEntraCPGuestUser_003@contoso.local")
 $temporaryPassword = @(
     (0..9 | Get-Random ),
     ('!', '@', '#', '$', '%', '^', '&', '*', '?', ';', '+' | Get-Random),
@@ -90,12 +96,12 @@ $passwordProfile = @{
 # Bulk add users
 $totalUsers = 50
 for ($i = 1; $i -le $totalUsers; $i++) {
-    $accountName = "$($accountNamePrefix)$("{0:D3}" -f $i)"
+    $accountName = "$($memberUsersNamePrefix)$("{0:D3}" -f $i)"
     $userPrincipalName = "$($accountName)@$($tenantName)"
     $user = Get-MgUser -Filter "UserPrincipalName eq '$userPrincipalName'"
     if ($null -eq $user) {
         $additionalUserAttributes = New-Object -TypeName HashTable
-        $userHasSpecificAttributes = [System.Linq.Enumerable]::FirstOrDefault($usersWithSpecificAttributes, [Func[object, bool]] { param($x) $x.UserPrincipalName -like $userPrincipalName })
+        $userHasSpecificAttributes = [System.Linq.Enumerable]::FirstOrDefault($usersWithSpecificSettings, [Func[object, bool]] { param($x) $x.UserPrincipalName -like $userPrincipalName })
         if ($null -ne $userHasSpecificAttributes.UserAttributes) {
             $additionalUserAttributes = $userHasSpecificAttributes.UserAttributes
         }
@@ -106,27 +112,31 @@ for ($i = 1; $i -le $totalUsers; $i++) {
 }
 
 # Add the guest users
-foreach ($guestUser in $guestUsers) {
-    $user = Get-MgUser -Filter "Mail eq '$($guestUser)'"
-    if ($null -eq $user) {
-        New-MgInvitation -InvitedUserDisplayName $guestUser -InvitedUserEmailAddress $guestUser -SendInvitationMessage:$false -InviteRedirectUrl "https://myapplications.microsoft.com"
-        Write-Host "Created guest user $guestUser" -ForegroundColor Green
+foreach ($guestUser in $guestUsersList) {
+    $guestUserInGraph = Get-MgUser -Filter "Mail eq '$($guestUser.Mail)'"
+    if ($null -eq $guestUserInGraph) {
+        $invitedUser = New-MgInvitation -InvitedUserDisplayName $guestUser.Mail -InvitedUserEmailAddress $guestUser.Mail -SendInvitationMessage:$false -InviteRedirectUrl "https://myapplications.microsoft.com"
+        Write-Host "Invited guest user $($invitedUser.InvitedUserEmailAddress)" -ForegroundColor Green
+        $guestUserInGraph = $invitedUser.InvitedUser
     }
+    $guestUser.Id = $guestUserInGraph.Id
+    $guestUser.UserPrincipalName = $guestUserInGraph.UserPrincipalName
 }
 
 # groups
-$allTestEntraUsers = Get-MgUser -ConsistencyLevel eventual -Count userCount -Filter "startsWith(DisplayName, '$($accountNamePrefix)')" -OrderBy UserPrincipalName
-$usersMemberOfAllGroups = [System.Linq.Enumerable]::Where($usersWithSpecificAttributes, [Func[object, bool]] { param($x) $x.IsMemberOfAllGroups -eq $true })
+$allMemberUsersInEntra = Get-MgUser -ConsistencyLevel eventual -Count userCount -Filter "startsWith(DisplayName, '$($memberUsersNamePrefix)')" -OrderBy UserPrincipalName
+$usersMemberOfAllGroups = [System.Linq.Enumerable]::Where($usersWithSpecificSettings, [Func[object, bool]] { param($x) $x.IsMemberOfAllGroups -eq $true })
 
 # Bulk add groups
 $totalGroups = 50
 for ($i = 1; $i -le $totalGroups; $i++) {
     $groupName = "$($groupNamePrefix)$("{0:D3}" -f $i)"
+    $groupSettings = [System.Linq.Enumerable]::FirstOrDefault($groupsWithSpecificSettings, [Func[object, bool]] { param($x) $x.GroupName -like $groupName })
     $entraGroup = Get-MgGroup -Filter "DisplayName eq '$($groupName)'"
+    $entraGroupJustCreated = $false
     if ($null -eq $entraGroup) {
         $newGroupCmdletParameters = New-Object -TypeName HashTable
         $newGroupCmdletParameters.add("SecurityEnabled", $true)
-        $groupSettings = [System.Linq.Enumerable]::FirstOrDefault($dtlGroupsSettings, [Func[object, bool]] { param($x) $x.GroupName -like $groupName })
         if ($null -ne $groupSettings) {
             if ($groupSettings.ContainsKey("SecurityEnabled") -and $groupSettings["SecurityEnabled"] -eq $false) {
                 $newGroupCmdletParameters["SecurityEnabled"] = $false
@@ -135,23 +145,37 @@ for ($i = 1; $i -le $totalGroups; $i++) {
 
         $entraGroup = New-MgGroup -GroupTypes "Unified" -DisplayName $groupName -MailNickName $groupName -MailEnabled:$False @newGroupCmdletParameters
         Write-Host "Created group $groupName" -ForegroundColor Green
-
-        # Set membership
-        $groupMembers = $usersMemberOfAllGroups | Select-Object -ExpandProperty UserPrincipalName
-        if ($null -ne $groupSettings -and $groupSettings.ContainsKey("AllTestUsersAreMembers") -and $groupSettings["AllTestUsersAreMembers"] -eq $true) {
-            $groupMembers = $allTestEntraUsers.UserPrincipalName
-        }
-
-        $groupMemberIds = New-Object -TypeName "System.Collections.Generic.List[System.String]"
-        foreach ($groupMember in $groupMembers) {
-            $entraUser = [System.Linq.Enumerable]::FirstOrDefault($allTestEntraUsers, [Func[object, bool]] { param($x) $x.UserPrincipalName -like $groupMember })
-            $groupMemberIds.Add($entraUser.Id)
-        }
-
-        # $groupMemberIds = $groupMemberIds | Select-Object -Unique
-        foreach ($groupMemberId in $groupMemberIds) {
-            New-MgGroupMember -GroupId $entraGroup.Id -DirectoryObjectId $groupMemberId
-        }
-        Write-Host "Added $($groupMemberIds.Count) member(s) to group $groupName" -ForegroundColor Green
+        $entraGroupJustCreated = $true
     }
+
+    if ($false -eq $entraGroupJustCreated) {
+        # Remove all members
+        $existingGroupMembers = Get-MgGroupMember -GroupId $entraGroup.Id
+        foreach ($groupMember in $existingGroupMembers) {
+            Remove-MgGroupMemberByRef -GroupId $entraGroup.Id -DirectoryObjectId $groupMember.Id
+        }
+        Write-Host "Removed all members of existing group $($entraGroup.DisplayName)." -ForegroundColor Green
+    }
+
+    # Set membership
+    $newGroupMembers = $usersMemberOfAllGroups | Select-Object -ExpandProperty UserPrincipalName
+    $newGroupMemberIds = New-Object -TypeName "System.Collections.Generic.List[System.String]"
+    if ($null -ne $groupSettings -and $groupSettings.ContainsKey("AllTestUsersAreMembers") -and $groupSettings["AllTestUsersAreMembers"] -eq $true) {
+        $newGroupMembers = $allMemberUsersInEntra.UserPrincipalName
+
+        foreach ($guestUser in $guestUsersList) {
+            $newGroupMemberIds.Add($guestUser.Id)
+        }
+    }
+
+    foreach ($groupMember in $newGroupMembers) {
+        $entraUser = [System.Linq.Enumerable]::FirstOrDefault($allMemberUsersInEntra, [Func[object, bool]] { param($x) $x.UserPrincipalName -like $groupMember })
+        $newGroupMemberIds.Add($entraUser.Id)
+    }
+
+    # $newGroupMemberIds = $newGroupMemberIds | Select-Object -Unique
+    foreach ($groupMemberId in $newGroupMemberIds) {
+        New-MgGroupMember -GroupId $entraGroup.Id -DirectoryObjectId $groupMemberId
+    }
+    Write-Host "Added $($newGroupMemberIds.Count) member(s) to group $($entraGroup.DisplayName)" -ForegroundColor Green
 }

--- a/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
+++ b/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicConfigurationTests.cs" />
+    <Compile Include="FilterUsersBasedOnGroupsTests.cs" />
     <Compile Include="SecurityEnabledGroupsTests.cs" />
     <Compile Include="ExcludeAUserTypeTests.cs" />
     <Compile Include="ClaimsProviderTestsBase.cs" />

--- a/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
+++ b/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
@@ -75,7 +75,7 @@
       <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="NUnit.Analyzers">
-      <Version>4.0.1</Version>
+      <Version>4.1.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Yvand.EntraCP/Package/Package.package
+++ b/Yvand.EntraCP/Package/Package.package
@@ -23,6 +23,7 @@
     <customAssembly location="Microsoft.Kiota.Serialization.Text.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Kiota.Serialization.Text.dll" />
     <customAssembly location="Std.UriTemplate.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Std.UriTemplate.dll" />   
     <customAssembly location="System.Buffers.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Buffers.dll" /> 
+	<customAssembly location="System.ClientModel.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.ClientModel.dll" /> 
     <customAssembly location="System.Diagnostics.DiagnosticSource.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.Diagnostics.DiagnosticSource.dll" />
     <customAssembly location="System.IdentityModel.Tokens.Jwt.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.IdentityModel.Tokens.Jwt.dll" />
     <customAssembly location="System.IO.FileSystem.AccessControl.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\System.IO.FileSystem.AccessControl.dll" />

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx
@@ -155,12 +155,12 @@
                             <asp:BoundField DataField="Id" ItemStyle-CssClass="Entracp-HideCol" HeaderStyle-CssClass="Entracp-HideCol" />
                             <asp:TemplateField HeaderText="Tenant + cloud instance">
                                 <ItemTemplate>
-                                    <asp:Label ID="grdAzureTenants_TenantNameLbl" runat="server" Text='<%# Bind("TenantName") %>'></asp:Label><br />
+                                    <asp:HyperLink id="grdAzureTenants_TenantNameLbl" NavigateUrl='<%# Eval("TenantName", "https://entra.microsoft.com/{0}/#view/Microsoft_AAD_IAM/TenantOverview.ReactView") %>' Text='<%# Bind("TenantName") %>' Target="_blank" runat="server"/><br />
                                     (in
                                     <asp:Label ID="grdAzureTenants_TenantCloudLbl" runat="server" Text='<%# Bind("AzureCloud") %>'></asp:Label>)
                                 </ItemTemplate>
                                 <EditItemTemplate>
-                                    <asp:Label ID="grdAzureTenants_TenantNameLbl" runat="server" Text='<%# Bind("TenantName") %>'></asp:Label>
+                                    <asp:HyperLink id="grdAzureTenants_TenantNameLbl" NavigateUrl='<%# Eval("TenantName", "https://entra.microsoft.com/{0}/#view/Microsoft_AAD_IAM/TenantOverview.ReactView") %>' Text='<%# Bind("TenantName") %>' Target="_blank" runat="server"/><br />
                                     (in
                                     <asp:Label ID="grdAzureTenants_TenantCloudLbl" runat="server" Text='<%# Bind("AzureCloud") %>'></asp:Label>)
                                 </EditItemTemplate>

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx
@@ -386,6 +386,28 @@
             <wssawc:InputFormTextBox title="Proxy address" class="ms-input" ID="InputProxyAddress" Columns="50" runat="server" />
         </Template_InputFormControls>
     </wssuc:InputFormSection>
+
+    <wssuc:InputFormSection runat="server" Title="Restrict searchable users">
+        <Template_Description>
+            <wssawc:EncodedLiteral runat="server" Text="Restrict the users who can be searched, by specifying a list of Entra groups. Only users members of any of those groups may be returned." EncodeMethod='NoEncode' />
+            <br />
+            <wssawc:EncodedLiteral runat="server" Text="You can specify up to 18 groups." EncodeMethod='NoEncode' />
+            <br />
+            <br />
+            <wssawc:EncodedLiteral runat="server" Text="For performance reasons, the members of those groups are stored in a local cache." EncodeMethod='NoEncode' />
+            <br />
+            <span>You can customize its lifetime (default value is <%= DefaultTenantDataCacheLifetimeInMinutes %> minutes), and the minimum possible value is 1 minute.</span>
+        </Template_Description>
+        <Template_InputFormControls>
+            <label for="<%= InputRestrictSearchableUsersByGroups.ClientID %>" title="Example: 1D6C19BB-DA3B-48D7-98FF-066CB9CA3F14,755D28C4-A2D8-4ACB-ADCE-68D4C6570938">List of groups ID separated by a comma &#9432;:</label><br />
+            <wssawc:InputFormTextBox title="Groups ID separated by a comma" class="ms-input" ID="InputRestrictSearchableUsersByGroups" Columns="50" runat="server" />
+            <br />
+            <br />
+            <label for="<%= InputTenantDataCacheLifetimeInMinutes.ClientID %>">Lifetime of the cache in minutes:</label><br />
+            <wssawc:InputFormTextBox class="ms-input" ID="InputTenantDataCacheLifetimeInMinutes" Columns="50" runat="server" />
+        </Template_InputFormControls>
+    </wssuc:InputFormSection>
+
     <wssuc:InputFormSection runat="server" Title="Reset EntraCP configuration" Description="Restore configuration to its default values. All changes, including in claim types mappings, will be lost.">
         <Template_InputFormControls>
             <asp:Button runat="server" ID="BtnResetConfig" Text="Reset EntraCP configuration" OnClick="BtnResetConfig_Click" class="ms-ButtonHeightWidth" OnClientClick="return confirm('Do you really want to reset EntraCP configuration?');" />

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx
@@ -143,7 +143,9 @@
             <wssawc:EncodedLiteral runat="server" Text="Microsoft Entra ID tenants currently registered in EntraCP configuration." EncodeMethod='HtmlEncodeAllowSimpleTextFormatting' />
             <br />
             <br />
-            <wssawc:EncodedLiteral runat="server" Text="<a href='https://entracp.yvand.net/docs/configure-the-credentials/' target='_blank'>Read this article</a> to find how to update the credentials on a tenant already registered." EncodeMethod='NoEncode' />
+            <wssawc:EncodedLiteral runat="server" Text="You can update the client secret here." EncodeMethod='HtmlEncodeAllowSimpleTextFormatting' />
+            <br />
+            <wssawc:EncodedLiteral runat="server" Text="<a href='https://entracp.yvand.net/docs/how-to/configure-the-credentials/' target='_blank'>Read this article</a> if you need to set a client certificate." EncodeMethod='NoEncode' />
         </Template_Description>
         <Template_InputFormControls>
             <tr>
@@ -151,12 +153,16 @@
                     <wssawc:SPGridView runat="server" ID="grdAzureTenants" AutoGenerateColumns="false" OnRowDeleting="grdAzureTenants_RowDeleting" OnRowEditing="grdAzureTenants_RowEditing" OnRowCancelingEdit="grdAzureTenants_RowCancelingEdit" OnRowUpdating="grdAzureTenants_RowUpdating" OnRowDataBound="grdAzureTenants_RowDataBound">
                         <Columns>
                             <asp:BoundField DataField="Id" ItemStyle-CssClass="Entracp-HideCol" HeaderStyle-CssClass="Entracp-HideCol" />
-                            <asp:TemplateField HeaderText="Tenant name">
+                            <asp:TemplateField HeaderText="Tenant + cloud instance">
                                 <ItemTemplate>
-                                    <asp:Label ID="grdAzureTenants_TenantNameLbl" runat="server" Text='<%# Bind("TenantName") %>'></asp:Label>
+                                    <asp:Label ID="grdAzureTenants_TenantNameLbl" runat="server" Text='<%# Bind("TenantName") %>'></asp:Label><br />
+                                    (in
+                                    <asp:Label ID="grdAzureTenants_TenantCloudLbl" runat="server" Text='<%# Bind("AzureCloud") %>'></asp:Label>)
                                 </ItemTemplate>
                                 <EditItemTemplate>
                                     <asp:Label ID="grdAzureTenants_TenantNameLbl" runat="server" Text='<%# Bind("TenantName") %>'></asp:Label>
+                                    (in
+                                    <asp:Label ID="grdAzureTenants_TenantCloudLbl" runat="server" Text='<%# Bind("AzureCloud") %>'></asp:Label>)
                                 </EditItemTemplate>
                             </asp:TemplateField>
                             <asp:TemplateField HeaderText="Client ID">

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx
@@ -134,39 +134,62 @@
 </table>
 <table border="0" cellspacing="0" cellpadding="0" width="100%">
     <wssuc:ButtonSection runat="server">
-        <template_buttons>
+        <Template_Buttons>
             <asp:Button UseSubmitBehavior="false" runat="server" class="ms-ButtonHeightWidth" OnClick="BtnOK_Click" Text="<%$Resources:wss,multipages_okbutton_text%>" ID="BtnOKTop" AccessKey="<%$Resources:wss,okbutton_accesskey%>" />
-        </template_buttons>
+        </Template_Buttons>
     </wssuc:ButtonSection>
     <wssuc:InputFormSection Title="Registered Microsoft Entra ID tenants" runat="server">
-        <template_description>
+        <Template_Description>
             <wssawc:EncodedLiteral runat="server" Text="Microsoft Entra ID tenants currently registered in EntraCP configuration." EncodeMethod='HtmlEncodeAllowSimpleTextFormatting' />
             <br />
             <br />
             <wssawc:EncodedLiteral runat="server" Text="<a href='https://entracp.yvand.net/docs/configure-the-credentials/' target='_blank'>Read this article</a> to find how to update the credentials on a tenant already registered." EncodeMethod='NoEncode' />
-        </template_description>
-        <template_inputformcontrols>
+        </Template_Description>
+        <Template_InputFormControls>
             <tr>
                 <td>
-                    <wssawc:SPGridView runat="server" ID="grdAzureTenants" AutoGenerateColumns="false" OnRowDeleting="grdAzureTenants_RowDeleting">
+                    <wssawc:SPGridView runat="server" ID="grdAzureTenants" AutoGenerateColumns="false" OnRowDeleting="grdAzureTenants_RowDeleting" OnRowEditing="grdAzureTenants_RowEditing" OnRowCancelingEdit="grdAzureTenants_RowCancelingEdit" OnRowUpdating="grdAzureTenants_RowUpdating" OnRowDataBound="grdAzureTenants_RowDataBound">
                         <Columns>
                             <asp:BoundField DataField="Id" ItemStyle-CssClass="Entracp-HideCol" HeaderStyle-CssClass="Entracp-HideCol" />
-                            <asp:BoundField HeaderText="Tenant" DataField="TenantName" />
-                            <asp:BoundField HeaderText="Application ID" DataField="ClientID" />
-                            <asp:BoundField HeaderText="Authentication mode" DataField="AuthenticationMode" />
-                            <asp:BoundField HeaderText="Extension Attributes Application ID" DataField="ExtensionAttributesApplicationId" />
-                            <asp:CommandField HeaderText="Action" ButtonType="Button" DeleteText="Remove" ShowDeleteButton="True" />
+                            <asp:TemplateField HeaderText="Tenant name">
+                                <ItemTemplate>
+                                    <asp:Label ID="grdAzureTenants_TenantNameLbl" runat="server" Text='<%# Bind("TenantName") %>'></asp:Label>
+                                </ItemTemplate>
+                                <EditItemTemplate>
+                                    <asp:Label ID="grdAzureTenants_TenantNameLbl" runat="server" Text='<%# Bind("TenantName") %>'></asp:Label>
+                                </EditItemTemplate>
+                            </asp:TemplateField>
+                            <asp:TemplateField HeaderText="Client ID">
+                                <ItemTemplate>
+                                    <asp:Label ID="grdAzureTenants_TenantClientIdLbl" runat="server" Text='<%# Bind("ClientID") %>'></asp:Label>
+                                </ItemTemplate>
+                                <EditItemTemplate>
+                                    <asp:Label runat="server" Text="New client ID:"></asp:Label><br />
+                                    <asp:TextBox ID="EditTenantNewClientID" runat="server" Text='<%# Bind("ClientID") %>' />
+                                </EditItemTemplate>
+                            </asp:TemplateField>
+                            <asp:TemplateField HeaderText="Credential">
+                                <ItemTemplate>
+                                    <asp:Label ID="grdAzureTenants_AuthenticationModeLbl" runat="server" Text='<%# Bind("AuthenticationMode") %>'></asp:Label>
+                                </ItemTemplate>
+                                <EditItemTemplate>
+                                    <asp:Label runat="server" Text="New secret  &#9432;:" ToolTip="Leave blank to keep the current secret or certificate"></asp:Label><br />
+                                    <asp:TextBox ID="EditTenantNewSecret" runat="server" ToolTip="New secret, or leave blank to keep the current secret or certificate" />
+                                </EditItemTemplate>
+                            </asp:TemplateField>
+                            <%--<asp:BoundField HeaderText="Extension Attributes Application ID" DataField="ExtensionAttributesApplicationId" />--%>
+                            <asp:CommandField HeaderText="Action" ButtonType="Button" ShowDeleteButton="True" DeleteText="Delete" ShowEditButton="true" EditText="Edit" />
                         </Columns>
                     </wssawc:SPGridView>
                 </td>
             </tr>
-        </template_inputformcontrols>
+        </Template_InputFormControls>
     </wssuc:InputFormSection>
     <wssuc:InputFormSection Title="Register a new Microsoft Entra ID tenant" runat="server">
-        <template_description>
+        <Template_Description>
             <wssawc:EncodedLiteral runat="server" Text="<p>EntraCP needs its own app registration to connect to your Microsoft Entra ID tenant, with permissions 'GroupMember.Read.All' and 'User.Read.All'.<br /><br />Read <a href='https://entracp.yvand.net/overview/register-application/' target='_blank'>this article</a> to find how to register the app in your tenant.<br /><br />EntraCP can authenticate using <a href='https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow#get-a-token' target='_blank'>either a secret or a certificate</a>.</p>" EncodeMethod='NoEncode' />
-        </template_description>
-        <template_inputformcontrols>
+        </Template_Description>
+        <Template_InputFormControls>
             <tr>
                 <td>
                     <div class="divfieldset">
@@ -223,10 +246,10 @@
                     </div>
                 </td>
             </tr>
-        </template_inputformcontrols>
+        </Template_InputFormControls>
     </wssuc:InputFormSection>
     <wssuc:InputFormSection runat="server" Title="Configuration for the user identifier">
-        <template_description>
+        <Template_Description>
             <sharepoint:encodedliteral runat="server" text="Specify the settings to search, create and display the permissions for users." encodemethod='HtmlEncodeAllowSimpleTextFormatting' />
             <br />
             <br />
@@ -239,8 +262,8 @@
             <sharepoint:encodedliteral runat="server" text="- For guests:" encodemethod='HtmlEncodeAllowSimpleTextFormatting' />
             <br />
             <b><span><%= UserIdentifierEncodedValuePrefix %><span id="lblGuestPermissionValuePreview"></span></span></b>
-        </template_description>
-        <template_inputformcontrols>
+        </Template_Description>
+        <Template_InputFormControls>
             <tr>
                 <td colspan="2">
                     <div class="divfieldset">
@@ -269,11 +292,11 @@
                     </div>
                 </td>
             </tr>
-        </template_inputformcontrols>
+        </Template_InputFormControls>
     </wssuc:InputFormSection>
 
     <wssuc:InputFormSection runat="server" Title="Configuration for the group identifier">
-        <template_description>
+        <Template_Description>
             <sharepoint:encodedliteral runat="server" text="Specify the settings to search, create and display the permissions for groups." encodemethod='HtmlEncodeAllowSimpleTextFormatting' />
             <br />
             <br />
@@ -283,8 +306,8 @@
             <br />
             <br />
             <sharepoint:encodedliteral runat="server" text="- Augmentation: If enabled, EntraCP gets the group membership of the users when they sign-in, or whenever SharePoint asks for it. If not enabled, permissions granted to Microsoft Entra ID groups may not work." encodemethod='HtmlEncodeAllowSimpleTextFormatting' />
-        </template_description>
-        <template_inputformcontrols>
+        </Template_Description>
+        <Template_InputFormControls>
             <tr>
                 <td colspan="2">
                     <div class="divfieldset">
@@ -319,11 +342,11 @@
                     </div>
                 </td>
             </tr>
-        </template_inputformcontrols>
+        </Template_InputFormControls>
     </wssuc:InputFormSection>
 
     <wssuc:InputFormSection runat="server" Title="Bypass Entra ID">
-        <template_description>
+        <Template_Description>
             <sharepoint:encodedliteral runat="server" text="Bypass the Entra ID tenant(s) registered and, depending on the context:" encodemethod='HtmlEncodeAllowSimpleTextFormatting' />
             <br />
             <sharepoint:encodedliteral runat="server" text="- Search: Uses the input as the claim's value, and return 1 entity per claim type." encodemethod='HtmlEncodeAllowSimpleTextFormatting' />
@@ -334,37 +357,37 @@
             <br />
             <br />
             <sharepoint:encodedliteral runat="server" text="It can be used as a mitigation if one or more SharePoint server(s) lost the connection with your Entra ID tenant(s), until it is restored." encodemethod='HtmlEncodeAllowSimpleTextFormatting' />
-        </template_description>
-        <template_inputformcontrols>
+        </Template_Description>
+        <Template_InputFormControls>
             <asp:CheckBox runat="server" Name="ChkAlwaysResolveUserInput" ID="ChkAlwaysResolveUserInput" Text="Bypass the Entra ID tenant(s) registered" />
-        </template_inputformcontrols>
+        </Template_InputFormControls>
     </wssuc:InputFormSection>
     <wssuc:InputFormSection runat="server" Title="Require exact match" Description="Enable this to return only results that match exactly the user input (case-insensitive).">
-        <template_inputformcontrols>
+        <Template_InputFormControls>
             <asp:CheckBox runat="server" Name="ChkFilterExactMatchOnly" ID="ChkFilterExactMatchOnly" Text="Require exact match when typing in the people picker" />
-        </template_inputformcontrols>
+        </Template_InputFormControls>
     </wssuc:InputFormSection>
 
     <wssuc:InputFormSection runat="server" Title="Proxy">
-        <template_description>
+        <Template_Description>
             <wssawc:EncodedLiteral runat="server" Text="Configure the proxy if it is needed for EntraCP to connect to Microsoft Graph." EncodeMethod='HtmlEncodeAllowSimpleTextFormatting' />
             <br />
             <br />
             <wssawc:EncodedLiteral runat="server" Text="Additional configuration in Windows may still be required. Read <a href='https://entracp.yvand.net/docs/configure-the-proxy/' target='_blank'>this article</a> to fully configure the proxy." EncodeMethod='NoEncode' />
-        </template_description>
-        <template_inputformcontrols>
+        </Template_Description>
+        <Template_InputFormControls>
             <label for="<%= InputProxyAddress.ClientID %>">Proxy address:</label><br />
             <wssawc:InputFormTextBox title="Proxy address" class="ms-input" ID="InputProxyAddress" Columns="50" runat="server" />
-        </template_inputformcontrols>
+        </Template_InputFormControls>
     </wssuc:InputFormSection>
     <wssuc:InputFormSection runat="server" Title="Reset EntraCP configuration" Description="Restore configuration to its default values. All changes, including in claim types mappings, will be lost.">
-        <template_inputformcontrols>
+        <Template_InputFormControls>
             <asp:Button runat="server" ID="BtnResetConfig" Text="Reset EntraCP configuration" OnClick="BtnResetConfig_Click" class="ms-ButtonHeightWidth" OnClientClick="return confirm('Do you really want to reset EntraCP configuration?');" />
-        </template_inputformcontrols>
+        </Template_InputFormControls>
     </wssuc:InputFormSection>
     <wssuc:ButtonSection runat="server">
-        <template_buttons>
+        <Template_Buttons>
             <asp:Button UseSubmitBehavior="false" runat="server" class="ms-ButtonHeightWidth" OnClick="BtnOK_Click" Text="<%$Resources:wss,multipages_okbutton_text%>" ID="BtnOK" AccessKey="<%$Resources:wss,okbutton_accesskey%>" />
-        </template_buttons>
+        </Template_Buttons>
     </wssuc:ButtonSection>
 </table>

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx.cs
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx.cs
@@ -70,7 +70,7 @@ namespace Yvand.EntraClaimsProvider.Administration
                     {
                         continue;
                     }
-                    pcb.AddRow(tenant.Identifier, tenant.Name, tenant.ClientId, tenant.AuthenticationMode, tenant.ExtensionAttributesApplicationId);
+                    pcb.AddRow(tenant.Identifier, tenant.Name, tenant.ClientId, tenant.AuthenticationMode, tenant.AzureCloud.ToString());
                 }
                 pcb.BindGrid(grdAzureTenants);
             }
@@ -364,7 +364,7 @@ namespace Yvand.EntraClaimsProvider.Administration
             var newTenant = new EntraIDTenant
             {
                 Name = this.TxtTenantName.Text,
-                AzureCloud = (AzureCloudName) Enum.Parse(typeof(AzureCloudName), this.DDLAzureCloudInstance.SelectedValue),
+                AzureCloud = (AzureCloudName)Enum.Parse(typeof(AzureCloudName), this.DDLAzureCloudInstance.SelectedValue),
                 ExcludeGuestUsers = this.ChkMemberUserTypeOnly.Checked,
                 ExtensionAttributesApplicationId = string.IsNullOrWhiteSpace(this.TxtExtensionAttributesApplicationId.Text) ? Guid.Empty : Guid.Parse(this.TxtExtensionAttributesApplicationId.Text)
             };
@@ -493,7 +493,10 @@ namespace Yvand.EntraClaimsProvider.Administration
             if (e.Row.RowType == DataControlRowType.DataRow)
             {
                 Button deleteButton = (Button)e.Row.Cells[4].Controls[2];
-                deleteButton.OnClientClick = "if(!confirm('Are you sure you want to delete this tenant?')) return;";
+                if (deleteButton != null && String.Equals(deleteButton.Text, "Delete", StringComparison.OrdinalIgnoreCase))
+                {
+                    deleteButton.OnClientClick = "if(!confirm('Are you sure you want to delete this tenant?')) return;";
+                }
             }
         }
     }
@@ -508,10 +511,10 @@ namespace Yvand.EntraClaimsProvider.Administration
             PropertyCollection.Columns.Add("ClientID", typeof(string));
             //PropertyCollection.Columns.Add("MemberUserTypeOnly", typeof(bool));
             PropertyCollection.Columns.Add("AuthenticationMode", typeof(string));
-            //PropertyCollection.Columns.Add("ExtensionAttributesApplicationId", typeof(Guid));
+            PropertyCollection.Columns.Add("AzureCloud", typeof(string));
         }
 
-        public void AddRow(Guid Id, string TenantName, string ClientID, string AuthenticationMode, Guid ExtensionAttributesApplicationId)
+        public void AddRow(Guid Id, string TenantName, string ClientID, string AuthenticationMode, string AzureCloud)
         {
             DataRow newRow = PropertyCollection.Rows.Add();
             newRow["Id"] = Id;
@@ -519,7 +522,7 @@ namespace Yvand.EntraClaimsProvider.Administration
             newRow["ClientID"] = ClientID;
             //newRow["MemberUserTypeOnly"] = MemberUserTypeOnly;
             newRow["AuthenticationMode"] = AuthenticationMode;
-            //newRow["ExtensionAttributesApplicationId"] = ExtensionAttributesApplicationId;
+            newRow["AzureCloud"] = AzureCloud;
         }
 
         public void BindGrid(SPGridView grid)

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx.cs
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx.cs
@@ -25,6 +25,8 @@ namespace Yvand.EntraClaimsProvider.Administration
 {
     public partial class GlobalSettingsUserControl : EntraCPUserControl
     {
+        protected int DefaultTenantDataCacheLifetimeInMinutes = ClaimsProviderConstants.DefaultTenantDataCacheLifetimeInMinutes;
+
         readonly string TextErrorNewTenantFieldsMissing = "Some mandatory fields are missing.";
         readonly string TextErrorTestAzureADConnection = "Unable to get access token for tenant '{0}': {1}";
         readonly string TextConnectionSuccessful = "Connection successful.";
@@ -122,6 +124,8 @@ namespace Yvand.EntraClaimsProvider.Administration
             this.ChkAlwaysResolveUserInput.Checked = Settings.AlwaysResolveUserInput;
             this.ChkFilterExactMatchOnly.Checked = Settings.FilterExactMatchOnly;
             this.InputProxyAddress.Text = Settings.ProxyAddress;
+            this.InputRestrictSearchableUsersByGroups.Text = Settings.RestrictSearchableUsersByGroups;
+            this.InputTenantDataCacheLifetimeInMinutes.Text = Settings.TenantDataCacheLifetimeInMinutes.ToString();
 
             AzureCloudName[] azureCloudNames = (AzureCloudName[])Enum.GetValues(typeof(AzureCloudName));
             foreach (var azureCloudName in azureCloudNames)
@@ -218,6 +222,8 @@ namespace Yvand.EntraClaimsProvider.Administration
             Settings.AlwaysResolveUserInput = this.ChkAlwaysResolveUserInput.Checked;
             Settings.FilterExactMatchOnly = this.ChkFilterExactMatchOnly.Checked;
             Settings.ProxyAddress = this.InputProxyAddress.Text;
+            Settings.RestrictSearchableUsersByGroups = this.InputRestrictSearchableUsersByGroups.Text;
+            Settings.TenantDataCacheLifetimeInMinutes = Convert.ToInt32(this.InputTenantDataCacheLifetimeInMinutes.Text);
 
             if (commitChanges) { CommitChanges(); }
             return true;

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx.cs
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx.cs
@@ -123,13 +123,12 @@ namespace Yvand.EntraClaimsProvider.Administration
             this.ChkFilterExactMatchOnly.Checked = Settings.FilterExactMatchOnly;
             this.InputProxyAddress.Text = Settings.ProxyAddress;
 
-            AzureCloudInstance[] azureCloudInstanceValues = (AzureCloudInstance[])Enum.GetValues(typeof(AzureCloudInstance));
-            foreach (var azureCloudInstanceValue in azureCloudInstanceValues)
+            AzureCloudName[] azureCloudNames = (AzureCloudName[])Enum.GetValues(typeof(AzureCloudName));
+            foreach (var azureCloudName in azureCloudNames)
             {
-                if (azureCloudInstanceValue == AzureCloudInstance.None) { continue; }
-                this.DDLAzureCloudInstance.Items.Add(new System.Web.UI.WebControls.ListItem(azureCloudInstanceValue.ToString(), azureCloudInstanceValue.ToString()));
+                this.DDLAzureCloudInstance.Items.Add(new ListItem(azureCloudName.ToString(), azureCloudName.ToString()));
             }
-            this.DDLAzureCloudInstance.SelectedValue = AzureCloudInstance.AzurePublic.ToString();
+            this.DDLAzureCloudInstance.SelectedValue = AzureCloudName.AzureGlobal.ToString();
         }
 
         private void PopulateGraphPropertiesLists()
@@ -244,12 +243,11 @@ namespace Yvand.EntraClaimsProvider.Administration
                 this.LabelErrorTestLdapConnection.Text = TextErrorNewTenantCreds;
                 return;
             }
-            AzureCloudInstance cloudInstance = (AzureCloudInstance)Enum.Parse(typeof(AzureCloudInstance), this.DDLAzureCloudInstance.SelectedValue);
 
             EntraIDTenant newTenant = new EntraIDTenant
             {
                 Name = this.TxtTenantName.Text,
-                AzureAuthority = ClaimsProviderConstants.AzureCloudEndpoints.FirstOrDefault(item => item.Key == cloudInstance).Value,
+                AzureCloud = (AzureCloudName)Enum.Parse(typeof(AzureCloudName), this.DDLAzureCloudInstance.SelectedValue),
             };
 
             if (String.IsNullOrWhiteSpace(this.TxtClientSecret.Text))
@@ -268,7 +266,6 @@ namespace Yvand.EntraClaimsProvider.Administration
 
             try
             {
-                //Task<bool> taskTestConnection = newTenant.TestConnectionAsync(Settings.ProxyAddress);
                 Task<bool> taskTestConnection = Task.Run(async () => await newTenant.TestConnectionAsync(Settings.ProxyAddress));
                 taskTestConnection.Wait();
                 bool success = taskTestConnection.Result;
@@ -359,9 +356,6 @@ namespace Yvand.EntraClaimsProvider.Administration
                 }
             }
 
-            Uri cloudInstance = ClaimsProviderConstants.AzureCloudEndpoints.FirstOrDefault(item => item.Key == (AzureCloudInstance)Enum.Parse(typeof(AzureCloudInstance), this.DDLAzureCloudInstance.SelectedValue)).Value;
-
-
             if (Settings.EntraIDTenants == null)
             {
                 Settings.EntraIDTenants = new List<EntraIDTenant>();
@@ -370,8 +364,8 @@ namespace Yvand.EntraClaimsProvider.Administration
             var newTenant = new EntraIDTenant
             {
                 Name = this.TxtTenantName.Text,
+                AzureCloud = (AzureCloudName) Enum.Parse(typeof(AzureCloudName), this.DDLAzureCloudInstance.SelectedValue),
                 ExcludeGuestUsers = this.ChkMemberUserTypeOnly.Checked,
-                AzureAuthority = cloudInstance,
                 ExtensionAttributesApplicationId = string.IsNullOrWhiteSpace(this.TxtExtensionAttributesApplicationId.Text) ? Guid.Empty : Guid.Parse(this.TxtExtensionAttributesApplicationId.Text)
             };
 
@@ -395,7 +389,7 @@ namespace Yvand.EntraClaimsProvider.Administration
             this.TxtClientSecret.Text = String.Empty;
             this.InputClientCertPassword.Text = String.Empty;
             this.TxtExtensionAttributesApplicationId.Text = String.Empty;
-            this.DDLAzureCloudInstance.SelectedValue = AzureCloudInstance.AzurePublic.ToString();
+            this.DDLAzureCloudInstance.SelectedValue = AzureCloudName.AzureGlobal.ToString();
         }
 
         private bool ValidateUploadedCertFile(

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx.designer.cs
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx.designer.cs
@@ -276,6 +276,24 @@ namespace Yvand.EntraClaimsProvider.Administration
         protected global::Microsoft.SharePoint.WebControls.InputFormTextBox InputProxyAddress;
 
         /// <summary>
+        /// InputRestrictSearchableUsersByGroups control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Microsoft.SharePoint.WebControls.InputFormTextBox InputRestrictSearchableUsersByGroups;
+
+        /// <summary>
+        /// InputTenantDataCacheLifetimeInMinutes control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Microsoft.SharePoint.WebControls.InputFormTextBox InputTenantDataCacheLifetimeInMinutes;
+
+        /// <summary>
         /// BtnResetConfig control.
         /// </summary>
         /// <remarks>

--- a/Yvand.EntraCP/Yvand.EntraCP.csproj
+++ b/Yvand.EntraCP/Yvand.EntraCP.csproj
@@ -128,10 +128,10 @@
   <!-- NuGet packages -->
   <ItemGroup>
     <PackageReference Include="Azure.Identity">
-      <Version>1.10.4</Version>
+      <Version>1.11.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph">
-      <Version>5.44.0</Version>
+      <Version>5.49.0</Version>
     </PackageReference>
     <PackageReference Include="StrongNamer">
       <Version>0.2.5</Version>
@@ -184,6 +184,7 @@ copy /Y "$(TargetDir)Microsoft.Kiota.Serialization.Multipart.dll" $(ProjectDir)\
 copy /Y "$(TargetDir)Microsoft.Kiota.Serialization.Text.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Std.UriTemplate.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Buffers.dll" $(ProjectDir)\bin
+copy /Y "$(TargetDir)System.ClientModel.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.Diagnostics.DiagnosticSource.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.IdentityModel.Tokens.Jwt.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)System.IO.FileSystem.AccessControl.dll" $(ProjectDir)\bin

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -99,6 +99,8 @@ namespace Yvand.EntraClaimsProvider.Configuration
 #else
         public static int DEFAULT_TIMEOUT = 15 * 1000;
 #endif
+
+        public static readonly int DefaultTenantDataCacheLifetimeInMinutes = 15;
     }
 
     public enum AzureCloudName

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -197,7 +197,10 @@ namespace Yvand.EntraClaimsProvider.Configuration
         /// </summary>
         public List<ClaimTypeConfig> CurrentClaimTypeConfigList { get; private set; }
 
-        public List<EntraIDTenant> AzureTenants { get; private set; }
+        /// <summary>
+        /// List of the Azure tenants registered, in an object that is unique to this thread, so none of its changes will be shared with other threads
+        /// </summary>
+        public List<EntraIDTenant> AzureTenantsCopy { get; private set; }
 
         public OperationContext(ClaimsProviderSettings settings, OperationType currentRequestType, string input, SPClaim incomingEntity, Uri context, string[] entityTypes, string hierarchyNodeID, int maxCount)
         {
@@ -209,12 +212,12 @@ namespace Yvand.EntraClaimsProvider.Configuration
             this.MaxCount = maxCount;
 
             // settings.EntraIDTenants must be cloned locally to ensure its properties ($select / $filter) won't be updated by multiple threads
-            this.AzureTenants = new List<EntraIDTenant>(settings.EntraIDTenants.Count);
+            this.AzureTenantsCopy = new List<EntraIDTenant>(settings.EntraIDTenants.Count);
             foreach (EntraIDTenant tenant in settings.EntraIDTenants)
             {
                 EntraIDTenant copy = new EntraIDTenant();
                 Utils.CopyPublicProperties(typeof(EntraIDTenant), tenant, copy);
-                AzureTenants.Add(copy);
+                AzureTenantsCopy.Add(copy);
             }
 
             if (entityTypes != null)

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
@@ -307,7 +307,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
             set => _TenantDataCacheLifetimeInMinutes = value;
         }
         [Persisted]
-        private int _TenantDataCacheLifetimeInMinutes;
+        private int _TenantDataCacheLifetimeInMinutes = ClaimsProviderConstants.DefaultTenantDataCacheLifetimeInMinutes;
         #endregion
 
         #region "Other properties"

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
@@ -56,25 +56,28 @@ namespace Yvand.EntraClaimsProvider.Configuration
 
         #region EntraID specific settings
         /// <summary>
-        /// Gets the list of Azure tenants to use to get entities
+        /// Gets the list of Entra ID tenants registered
         /// </summary>
         List<EntraIDTenant> EntraIDTenants { get; }
 
         /// <summary>
-        /// Gets the proxy address used by AzureCP to connect to Azure AD
+        /// Gets the proxy address used by EntraCP to connect to your Entra ID tenant
         /// </summary>
         string ProxyAddress { get; }
 
         /// <summary>
-        /// Gets if only security-enabled groups should be returned
+        /// Gets if only security-enabled groups should be returned - https://docs.microsoft.com/en-us/graph/api/resources/groups-overview?view=graph-rest-1.0
         /// </summary>
         bool FilterSecurityEnabledGroupsOnly { get; }
 
         /// <summary>
-        /// Comma separated list of group IDs (max 18 values). If set, users must be member of any of these groups to be returned to SharePoint
+        /// Gets a list of Entra groups ID (max 18 values), separated by a comma. Users must be members of at least 1, to be searchable. Leave empty to not apply any filtering.
         /// </summary>
-        string GroupsWhichUsersMustBeMemberOfAny { get; }
+        string RestrictSearchableUsersByGroups { get; }
 
+        /// <summary>
+        /// Gets the lifetime in minutes of the cache which stores data from Entra ID which may be time-consuming to retrieve with each request
+        /// </summary>
         int TenantDataCacheLifetimeInMinutes { get; }
         #endregion
     }
@@ -96,8 +99,8 @@ namespace Yvand.EntraClaimsProvider.Configuration
         public List<EntraIDTenant> EntraIDTenants { get; set; } = new List<EntraIDTenant>();
         public string ProxyAddress { get; set; }
         public bool FilterSecurityEnabledGroupsOnly { get; set; } = false;
-        public string GroupsWhichUsersMustBeMemberOfAny { get; set; }
-        public int TenantDataCacheLifetimeInMinutes { get; set; } = 15;
+        public string RestrictSearchableUsersByGroups { get; set; }
+        public int TenantDataCacheLifetimeInMinutes { get; set; } = ClaimsProviderConstants.DefaultTenantDataCacheLifetimeInMinutes;
         #endregion
 
         public EntraIDProviderSettings() { }
@@ -251,6 +254,9 @@ namespace Yvand.EntraClaimsProvider.Configuration
 
 
         #region "EntraID settings implemented from IEntraIDEntityProviderSettings"
+        /// <summary>
+        /// Gets or sets the list of Entra ID tenants registered
+        /// </summary>
         public List<EntraIDTenant> EntraIDTenants
         {
             get => _EntraIDTenants;
@@ -259,6 +265,9 @@ namespace Yvand.EntraClaimsProvider.Configuration
         [Persisted]
         private List<EntraIDTenant> _EntraIDTenants = new List<EntraIDTenant>();
 
+        /// <summary>
+        /// Gets or sets the proxy address used by EntraCP to connect to your Entra ID tenant
+        /// </summary>
         public string ProxyAddress
         {
             get => _ProxyAddress;
@@ -268,7 +277,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
         private string _ProxyAddress;
 
         /// <summary>
-        /// Set if only AAD groups with securityEnabled = true should be returned - https://docs.microsoft.com/en-us/graph/api/resources/groups-overview?view=graph-rest-1.0
+        /// Gets or sets if only security-enabled groups should be returned - https://docs.microsoft.com/en-us/graph/api/resources/groups-overview?view=graph-rest-1.0
         /// </summary>
         public bool FilterSecurityEnabledGroupsOnly
         {
@@ -279,15 +288,15 @@ namespace Yvand.EntraClaimsProvider.Configuration
         private bool _FilterSecurityEnabledGroupsOnly = false;
 
         /// <summary>
-        /// Gets or sets the ID of the Entra ID groups that users must be members of, to be returned by EntraCP. Leave empty to not apply any filtering.
+        /// Gets or sets a list of Entra groups ID (max 18 values), separated by a comma. Users must be members of at least 1, to be searchable. Leave empty to not apply any filtering.
         /// </summary>
-        public string GroupsWhichUsersMustBeMemberOfAny
+        public string RestrictSearchableUsersByGroups
         {
-            get => _GroupsWhichUsersMustBeMemberOfAny;
-            set => _GroupsWhichUsersMustBeMemberOfAny = value;
+            get => _RestrictSearchableUsersByGroups;
+            set => _RestrictSearchableUsersByGroups = value;
         }
         [Persisted]
-        private string _GroupsWhichUsersMustBeMemberOfAny;
+        private string _RestrictSearchableUsersByGroups;
 
         /// <summary>
         /// Gets or sets the lifetime in minutes of the cache which stores data from Entra ID which may be time-consuming to retrieve with each request
@@ -369,7 +378,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
                 EntraIDTenants = this.EntraIDTenants,
                 ProxyAddress = this.ProxyAddress,
                 FilterSecurityEnabledGroupsOnly = this.FilterSecurityEnabledGroupsOnly,
-                GroupsWhichUsersMustBeMemberOfAny = this.GroupsWhichUsersMustBeMemberOfAny,
+                RestrictSearchableUsersByGroups = this.RestrictSearchableUsersByGroups,
                 TenantDataCacheLifetimeInMinutes = this.TenantDataCacheLifetimeInMinutes,
             };
             return (IEntraIDProviderSettings)entityProviderSettings;
@@ -508,26 +517,26 @@ namespace Yvand.EntraClaimsProvider.Configuration
                 }
             }
 
-            if (this.TenantDataCacheLifetimeInMinutes < 0)
+            if (this.TenantDataCacheLifetimeInMinutes < 1)
             {
-                throw new InvalidOperationException($"The configuration is invalid because property {nameof(TenantDataCacheLifetimeInMinutes)} has a negative value.");
+                throw new InvalidOperationException($"The configuration is invalid because property {nameof(TenantDataCacheLifetimeInMinutes)} is set to 0 or a negative value. Minimum value is 1");
             }
 
-            if (this.GroupsWhichUsersMustBeMemberOfAny != null)
+            if (this.RestrictSearchableUsersByGroups != null)
             {
-                string[] groupsId = this.GroupsWhichUsersMustBeMemberOfAny.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] groupsId = this.RestrictSearchableUsersByGroups.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 // Batch request size limit in Graph is 20: https://learn.microsoft.com/en-us/graph/json-batching#batch-size-limitations
                 // So max is 18 + 1 to get users + 1 to get groups
                 if (groupsId.Length > 18)
                 {
-                    throw new InvalidOperationException($"The configuration is invalid because property {nameof(GroupsWhichUsersMustBeMemberOfAny)} exceeds the limit of 18 groups, which would generate a batch request too big for Graph. More information in https://learn.microsoft.com/en-us/graph/json-batching#batch-size-limitations");
+                    throw new InvalidOperationException($"The configuration is invalid because property {nameof(RestrictSearchableUsersByGroups)} exceeds the limit of 18 groups, which would generate a batch request too big for Graph. More information in https://learn.microsoft.com/en-us/graph/json-batching#batch-size-limitations");
                 }
                 Guid testGuidResult = Guid.Empty;
                 foreach (string groupId in groupsId)
                 {
                     if (!Guid.TryParse(groupId, out testGuidResult))
                     {
-                        throw new InvalidOperationException($"The configuration is invalid because property {nameof(GroupsWhichUsersMustBeMemberOfAny)} is not set correctly. It should be a csv list of group IDs");
+                        throw new InvalidOperationException($"The configuration is invalid because property {nameof(RestrictSearchableUsersByGroups)} is not set correctly. It should be a csv list of group IDs");
                     }
                 }
             }
@@ -585,7 +594,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
             this.EntraIDTenants = settings.EntraIDTenants;
             this.FilterSecurityEnabledGroupsOnly = settings.FilterSecurityEnabledGroupsOnly;
             this.ProxyAddress = settings.ProxyAddress;
-            this.GroupsWhichUsersMustBeMemberOfAny = settings.GroupsWhichUsersMustBeMemberOfAny;
+            this.RestrictSearchableUsersByGroups = settings.RestrictSearchableUsersByGroups;
             this.TenantDataCacheLifetimeInMinutes = settings.TenantDataCacheLifetimeInMinutes;
 
             if (commitChangesInDatabase)

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
@@ -118,23 +118,14 @@ namespace Yvand.EntraClaimsProvider.Configuration
             get => _ExtensionAttributesApplicationId;
             set => _ExtensionAttributesApplicationId = value;
         }
-
-        public Uri AzureAuthority
+        
+        public AzureCloudName AzureCloud
         {
-            get => new Uri(this._AzureAuthority);
-            set => _AzureAuthority = value.ToString();
+            get => _AzureCloud;
+            set => _AzureCloud = value;
         }
         [Persisted]
-        private string _AzureAuthority = AzureAuthorityHosts.AzurePublicCloud.ToString();
-        public AzureCloudInstance CloudInstance
-        {
-            get
-            {
-                if (AzureAuthority == null) { return AzureCloudInstance.AzurePublic; }
-                KeyValuePair<AzureCloudInstance, Uri> kvp = ClaimsProviderConstants.AzureCloudEndpoints.FirstOrDefault(item => item.Value.Equals(this.AzureAuthority));
-                return kvp.Equals(default(KeyValuePair<AzureCloudInstance, Uri>)) ? AzureCloudInstance.AzurePublic : kvp.Key;
-            }
-        }
+        private AzureCloudName _AzureCloud = AzureCloudName.AzureGlobal;
 
         public string AuthenticationMode
         {
@@ -202,6 +193,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
                 requestsTimeout = ClaimsProviderConstants.DEFAULT_TIMEOUT;
             }
 
+
             WebProxy webProxy = null;
             HttpClientTransport clientTransportProxy = null;
             if (!String.IsNullOrWhiteSpace(proxyAddress))
@@ -221,9 +213,10 @@ namespace Yvand.EntraClaimsProvider.Configuration
             //handlers.Remove(retryHandler);
 #endif
 
+            AzureCloudProperties cloudInstanceSettings = ClaimsProviderConstants.AzureClouds.First(x => x.Name == AzureCloud);
             TokenCredentialOptions options = new TokenCredentialOptions
             {
-                AuthorityHost = this.AzureAuthority,
+                AuthorityHost = new Uri(cloudInstanceSettings.Authority),
                 Retry =
                 {
                     NetworkTimeout = TimeSpan.FromMilliseconds(requestsTimeout),
@@ -249,10 +242,10 @@ namespace Yvand.EntraClaimsProvider.Configuration
                 tokenCredential = new ClientCertificateCredential(this.Name, this.ClientId, this.ClientCertificateWithPrivateKey, options);
             }
 
-            HttpClient httpClient = GraphClientFactory.Create(handlers: handlers, proxy: webProxy);
+            HttpClient httpClient = GraphClientFactory.Create(handlers: handlers, proxy: webProxy, nationalCloud: cloudInstanceSettings.NameInGraphCore);
             httpClient.Timeout = TimeSpan.FromMilliseconds(requestsTimeout);
-            var scopes = new[] { "https://graph.microsoft.com/.default" };
-            this.GraphService = new GraphServiceClient(httpClient, tokenCredential, scopes);
+            this.GraphService = new GraphServiceClient(httpClient, tokenCredential, new[] { cloudInstanceSettings.GraphScope });
+            Logger.Log($"[{EntraCP.ClaimsProviderName}] Initialized authentication for tenant \"{this.Name}\" on cloud instance \"{cloudInstanceSettings.Name}\" (authority \"{cloudInstanceSettings.Authority}\" and scope \"{cloudInstanceSettings.GraphScope}\").", TraceSeverity.High, EventSeverity.Information, TraceCategory.Configuration);
         }
 
         public async Task<bool> TestConnectionAsync(string proxyAddress)

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
@@ -72,7 +72,12 @@ namespace Yvand.EntraClaimsProvider.Configuration
             }
             protected set
             {
-                if (value == null) { return; }
+                if (value == null)
+                {
+                    _ClientCertificateWithPrivateKey = value;
+                    return;
+                }
+
                 if (!value.HasPrivateKey) { throw new ArgumentException("The certificate cannot be imported because it does not have a private key"); }
                 _ClientCertificateWithPrivateKey = value;
                 try

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
@@ -151,8 +151,8 @@ namespace Yvand.EntraClaimsProvider.Configuration
         public string[] GroupSelect { get; set; }
 
         public EntraIDTenant() { }
-        
-        public EntraIDTenant(string tenantName) 
+
+        public EntraIDTenant(string tenantName)
         {
             this.Name = tenantName;
         }

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Yvand.EntraClaimsProvider.Configuration;
 using Yvand.EntraClaimsProvider.Logging;
@@ -25,16 +26,25 @@ namespace Yvand.EntraClaimsProvider
     public class EntraIDEntityProvider : EntityProviderBase
     {
         public IClaimsProviderSettings Settings { get; }
+        private static List<CachedEntraIDTenantData> CachedTenantData;
+
         public EntraIDEntityProvider(string claimsProviderName, IClaimsProviderSettings Settings) : base(claimsProviderName)
         {
             this.Settings = Settings;
+
+            // Reset cache if config changes
+            CachedTenantData = new List<CachedEntraIDTenantData>();
+            foreach (var tenant in this.Settings.EntraIDTenants)
+            {
+                CachedTenantData.Add(new CachedEntraIDTenantData(tenant.Identifier, Settings.TenantDataCacheLifetimeInMinutes));
+            }
         }
 
         public async override Task<List<string>> GetEntityGroupsAsync(OperationContext currentContext)
         {
             DirectoryObjectProperty groupProperty = Settings.GroupIdentifierClaimTypeConfig.EntityProperty;
             // Create 1 Task for each tenant to query
-            IEnumerable<Task<List<string>>> tenantTasks = currentContext.AzureTenants.Select(async tenant =>
+            IEnumerable<Task<List<string>>> tenantTasks = currentContext.AzureTenantsCopy.Select(async tenant =>
             {
                 // Wrap the call to GetEntityGroupsFromTenantAsync() in a Task to avoid a hang when using the "check permissions" dialog
                 using (new SPMonitoredScope($"[{ClaimsProviderName}] Get groups of user \"{currentContext.IncomingEntity.Value}\" from tenant \"{tenant.Name}\"", 1000))
@@ -164,8 +174,8 @@ namespace Yvand.EntraClaimsProvider
             //{
             //    azureTenants.Add(tenant.CopyPublicProperties());
             //}
-            this.BuildFilter(currentContext, currentContext.AzureTenants);
-            List<DirectoryObject> results = await this.QueryEntraIDTenantsAsync(currentContext, currentContext.AzureTenants);
+            this.BuildFilter(currentContext, currentContext.AzureTenantsCopy);
+            List<DirectoryObject> results = await this.QueryEntraIDTenantsAsync(currentContext, currentContext.AzureTenantsCopy);
             return results;
         }
 
@@ -180,7 +190,7 @@ namespace Yvand.EntraClaimsProvider
 
             List<string> userFilterBuilder = new List<string>();
             List<string> groupFilterBuilder = new List<string>();
-            List<string> userSelectBuilder = new List<string> { "UserType", "Mail" };    // UserType and Mail are always needed to deal with Guest users
+            List<string> userSelectBuilder = new List<string> { "Id", "UserType", "Mail" };    // UserType and Mail are always needed to deal with Guest users
             List<string> groupSelectBuilder = new List<string> { "Id", "securityEnabled" };               // Id is always required for groups
 
 
@@ -324,7 +334,7 @@ namespace Yvand.EntraClaimsProvider
                 {
                     Stopwatch timer = new Stopwatch();
                     timer.Start();
-                    List<DirectoryObject> tenantResults = await QueryEntraIDTenantAsync(currentContext, tenant).ConfigureAwait(false);
+                    List<DirectoryObject> tenantResults = await QueryEntraIDTenantAsync(currentContext, tenant, CachedTenantData.First(x => x.TenantIdentifier == tenant.Identifier)).ConfigureAwait(false);
                     timer.Stop();
                     if (tenantResults != null)
                     {
@@ -352,7 +362,7 @@ namespace Yvand.EntraClaimsProvider
             return allResults;
         }
 
-        protected virtual async Task<List<DirectoryObject>> QueryEntraIDTenantAsync(OperationContext currentContext, EntraIDTenant tenant)
+        protected virtual async Task<List<DirectoryObject>> QueryEntraIDTenantAsync(OperationContext currentContext, EntraIDTenant tenant, CachedEntraIDTenantData cachedTenantData)
         {
             List<DirectoryObject> tenantResults = new List<DirectoryObject>();
             if (String.IsNullOrWhiteSpace(tenant.UserFilter) && String.IsNullOrWhiteSpace(tenant.GroupFilter))
@@ -371,7 +381,7 @@ namespace Yvand.EntraClaimsProvider
             int timeout = this.Settings.Timeout;
             int maxRetry = currentContext.OperationType == OperationType.Validation ? 3 : 2;
             int tenantResultCount = 0;
-
+            bool lockToWriteInCachedDataWasTaken = false;
             try
             {
                 using (new SPMonitoredScope($"[{ClaimsProviderName}] Querying Microsoft Entra ID tenant '{tenant.Name}' for users and groups, with input '{currentContext.Input}'", 1000))
@@ -450,6 +460,44 @@ namespace Yvand.EntraClaimsProvider
                         groupsRequestId = await batchRequestContent.AddBatchRequestStepAsync(groupRequest).ConfigureAwait(false);
                     }
 
+                    // List of groups that users must be member of, to be returned to SharePoint
+                    string[] groupsWhichUsersMustBeMemberOfRequestIds = null;
+                    string groupsWhichUsersMustBeMemberOfAny = this.Settings.GroupsWhichUsersMustBeMemberOfAny;
+                    //groupsWhichUsersMustBeMemberOfAny = "c9a94341-89b5-4109-a501-2a14027b5bf0"; // testEntraCPGroup_005 - everyone member
+                    //groupsWhichUsersMustBeMemberOfAny = "cd5f135c-9fe5-4ec2-90d9-114e9ad2e236"; // testEntraCPGroup_004 - testEntraCPUser_001 and testEntraCPUser_010 members
+                    if (!String.IsNullOrWhiteSpace(groupsWhichUsersMustBeMemberOfAny) && cachedTenantData.UserIdsMembersOfAnyRequiredGroup == null)
+                    {
+                        await cachedTenantData.WriteDataLock.WaitAsync().ConfigureAwait(false);
+                        lockToWriteInCachedDataWasTaken = true;
+                        if (cachedTenantData.UserIdsMembersOfAnyRequiredGroup != null)
+                        {
+                            cachedTenantData.WriteDataLock.Release();
+                            lockToWriteInCachedDataWasTaken = false;
+                        }
+                        else
+                        {
+                            string[] groupIds = groupsWhichUsersMustBeMemberOfAny.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                            groupsWhichUsersMustBeMemberOfRequestIds = new string[groupIds.Length];
+                            int groupIdx = 0;
+                            foreach (string groupId in groupIds)
+                            {
+                                RequestInformation usersMembersOfGroupRequest = tenant.GraphService.Groups[groupId].Members.GraphUser.ToGetRequestInformation(conf =>
+                                {
+                                    conf.QueryParameters = new Microsoft.Graph.Groups.Item.Members.GraphUser.GraphUserRequestBuilder.GraphUserRequestBuilderGetQueryParameters
+                                    {
+                                        Select = new string[] { "Id" },
+                                    };
+                                    conf.Options = new List<IRequestOption>
+                                    {
+                                    retryHandlerOption,
+                                    };
+                                });
+                                groupsWhichUsersMustBeMemberOfRequestIds[groupIdx] = await batchRequestContent.AddBatchRequestStepAsync(usersMembersOfGroupRequest).ConfigureAwait(false);
+                                groupIdx++;
+                            }
+                        }
+                    }
+
                     // Run the batch request and get the HTTP status code of each request inside the batch
                     BatchResponseContentCollection batchResponse = await tenant.GraphService.Batch.PostAsync(batchRequestContent).ConfigureAwait(false);
                     Dictionary<string, HttpStatusCode> requestsStatusInBatchResponse = await batchResponse.GetResponsesStatusCodesAsync().ConfigureAwait(false);
@@ -484,6 +532,31 @@ namespace Yvand.EntraClaimsProvider
                         }
                     }
 
+                    if (groupsWhichUsersMustBeMemberOfRequestIds != null)
+                    {
+                        // only need 1 list that contains unique user ids
+                        cachedTenantData.UserIdsMembersOfAnyRequiredGroup = new List<string>();
+                        foreach (string groupsWhichUsersMustBeMemberOfRequestId in groupsWhichUsersMustBeMemberOfRequestIds)
+                        {
+                            HttpStatusCode usersMembersOfAnyRequiredGroupResponseStatus;
+                            UserCollectionResponse usersMembersOfAnyRequiredGroupResponse = null;
+                            if (requestsStatusInBatchResponse.TryGetValue(groupsWhichUsersMustBeMemberOfRequestId, out usersMembersOfAnyRequiredGroupResponseStatus))
+                            {
+                                if (usersMembersOfAnyRequiredGroupResponseStatus == HttpStatusCode.OK)
+                                {
+                                    usersMembersOfAnyRequiredGroupResponse = await batchResponse.GetResponseByIdAsync<UserCollectionResponse>(groupsWhichUsersMustBeMemberOfRequestId).ConfigureAwait(false);
+                                    cachedTenantData.UserIdsMembersOfAnyRequiredGroup.AddRange(usersMembersOfAnyRequiredGroupResponse.Value.Where(x => !cachedTenantData.UserIdsMembersOfAnyRequiredGroup.Contains(x.Id)).Select(x => x.Id).ToList());
+                                }
+                                else
+                                {
+                                    Logger.Log($"[{ClaimsProviderName}] Request inside the batch returned unexpected status '{usersMembersOfAnyRequiredGroupResponseStatus}' for tenant '{tenant.Name}', to get users members of a group ", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Lookup);
+                                }
+                            }
+                        }
+                        cachedTenantData.WriteDataLock.Release();
+                        lockToWriteInCachedDataWasTaken = false;
+                    }
+
                     Logger.Log($"[{ClaimsProviderName}] Query to tenant '{tenant.Name}' returned {(userCollectionResult?.Value == null ? 0 : userCollectionResult.Value.Count)} user(s) with filter \"{tenant.UserFilter}\" and {(groupCollectionResult?.Value == null ? 0 : groupCollectionResult.Value.Count)} group(s) with filter \"{tenant.GroupFilter}\"", TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Lookup);
                     // Process users result
                     if (userCollectionResult?.Value != null)
@@ -508,6 +581,11 @@ namespace Yvand.EntraClaimsProvider
                                     {
                                         addUser = true;
                                     }
+                                }
+
+                                if (cachedTenantData.UserIdsMembersOfAnyRequiredGroup != null && !cachedTenantData.UserIdsMembersOfAnyRequiredGroup.Contains(user.Id))
+                                {
+                                    addUser = false;
                                 }
 
                                 bool continueIteration = true;
@@ -591,6 +669,11 @@ namespace Yvand.EntraClaimsProvider
             }
             finally
             {
+                if (lockToWriteInCachedDataWasTaken)
+                {
+                    cachedTenantData.WriteDataLock.Release();
+                    lockToWriteInCachedDataWasTaken = false;
+                }
             }
             return tenantResults;
         }
@@ -660,6 +743,46 @@ namespace Yvand.EntraClaimsProvider
             }   // Property doesn't exist
             object propertyValue = pi.GetValue(directoryObject, null);
             return propertyValue == null ? String.Empty : propertyValue.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Cache of data fetched from an Entra ID tenant
+    /// </summary>
+    public class CachedEntraIDTenantData
+    {
+        public Guid TenantIdentifier;
+        public SemaphoreSlim WriteDataLock = new SemaphoreSlim(1, 1);
+        public List<string> UserIdsMembersOfAnyRequiredGroup
+        {
+            get
+            {
+                if (UserIdsMembersOfAnyRequiredGroupCacheTime == default(DateTime))
+                {
+                    return _UserIdsMembersOfAnyRequiredGroup;
+                }
+                TimeSpan interval = DateTime.UtcNow - UserIdsMembersOfAnyRequiredGroupCacheTime;
+                if (interval > UserIdsMembersOfAnyRequiredGroupCacheTTL)
+                {
+                    UserIdsMembersOfAnyRequiredGroupCacheTime = default(DateTime);
+                    _UserIdsMembersOfAnyRequiredGroup = null;
+                }
+                return _UserIdsMembersOfAnyRequiredGroup;
+            }
+            set
+            {
+                _UserIdsMembersOfAnyRequiredGroup = value;
+                UserIdsMembersOfAnyRequiredGroupCacheTime = DateTime.UtcNow;
+            }
+        }
+        private List<string> _UserIdsMembersOfAnyRequiredGroup;
+        private DateTime UserIdsMembersOfAnyRequiredGroupCacheTime;
+        private TimeSpan UserIdsMembersOfAnyRequiredGroupCacheTTL = new TimeSpan(0, 1, 0);
+
+        public CachedEntraIDTenantData(Guid tenantIdentifier, int tenantDataCacheLifetimeInMinutes)
+        {
+            this.TenantIdentifier = tenantIdentifier;
+            this.UserIdsMembersOfAnyRequiredGroupCacheTTL = new TimeSpan(0, tenantDataCacheLifetimeInMinutes, 0);
         }
     }
 }

--- a/assembly-bindings.config
+++ b/assembly-bindings.config
@@ -12,11 +12,11 @@ The content of this file may change with each version of EntraCP, make sure to u
 <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
     <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral"/>
-        <bindingRedirect oldVersion="1.36.0.0" newVersion="1.37.0.0"/>
+        <bindingRedirect oldVersion="1.37.0.0" newVersion="1.38.0.0"/>
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="1.7.6.0-1.7.8.0" newVersion="1.7.9.0"/>
+        <bindingRedirect oldVersion="1.7.10.0-1.7.11.0" newVersion="1.8.0.0"/>
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
@@ -24,7 +24,7 @@ The content of this file may change with each version of EntraCP, make sure to u
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="6.22.0.0" newVersion="7.3.1.0"/>
+        <bindingRedirect oldVersion="6.35.0.0" newVersion="7.4.1.0"/>
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>


### PR DESCRIPTION
## Changelog

* Update the global configuration page to give the possibility to update the credentials of tenants already registered - https://github.com/Yvand/EntraCP/pull/248
* Fix an issue where tenant credentials could not be changed from a client certificate to a client secret - https://github.com/Yvand/EntraCP/pull/248
* Prompt user for confirmation before actually deleting a tenant - https://github.com/Yvand/EntraCP/pull/248
* New feature: It is now possible to configure EntraCP, to return only users that are members of some Entra groups, configured by the administrator - https://github.com/Yvand/EntraCP/pull/243
* Fix the connection to Microsoft Graph not working when the tenant is hosted in a national cloud
* Update Azure.Identity from 1.10.4 to 1.11.2
* Update Microsoft.Graph from 5.44.0 to 5.49.0