### PR TITLE
 Publish EntraCP v26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for ~~AzureCP~~ EntraCP
 
+## Unreleased
+
+* Fix an NullReferenceException in a very rare scenario where ClaimsPrincipal.Identity is null
+
 ## EntraCP v25.0.20240503.33 enhancements & bug-fixes - Published in May 3, 2024
 
 * Update the global configuration page to give the possibility to update the credentials of tenants already registered - https://github.com/Yvand/EntraCP/pull/248

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix an NullReferenceException in a very rare scenario where ClaimsPrincipal.Identity is null
+* Add helper methods to get/delete a tenant in the configuration
 
 ## EntraCP v25.0.20240503.33 enhancements & bug-fixes - Published in May 3, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fix an NullReferenceException in a very rare scenario where ClaimsPrincipal.Identity is null
 * Add helper methods to get/delete a tenant in the configuration
+* Update Azure.Identity from 1.11.2 to 1.12.0
+* Update Microsoft.Graph from 5.49.0 to 5.56.0
 
 ## EntraCP v25.0.20240503.33 enhancements & bug-fixes - Published in May 3, 2024
 

--- a/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
+++ b/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
@@ -76,7 +76,7 @@
       <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="NUnit.Analyzers">
-      <Version>4.1.0</Version>
+      <Version>4.2.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Yvand.EntraCP/Yvand.EntraCP.csproj
+++ b/Yvand.EntraCP/Yvand.EntraCP.csproj
@@ -128,10 +128,10 @@
   <!-- NuGet packages -->
   <ItemGroup>
     <PackageReference Include="Azure.Identity">
-      <Version>1.11.2</Version>
+      <Version>1.12.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph">
-      <Version>5.49.0</Version>
+      <Version>5.56.0</Version>
     </PackageReference>
     <PackageReference Include="StrongNamer">
       <Version>0.2.5</Version>

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -282,7 +282,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
             if (httpctx != null)
             {
                 WIF4_5.ClaimsPrincipal cp = httpctx.User as WIF4_5.ClaimsPrincipal;
-                if (cp != null)
+                if (cp != null && cp.Identity != null)
                 {
                     if (SPClaimProviderManager.IsEncodedClaim(cp.Identity.Name))
                     {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
@@ -404,7 +404,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
                 throw new ArgumentNullException(nameof(newClientSecret));
             }
 
-            EntraIDTenant tenant = this.EntraIDTenants.FirstOrDefault(x => x.Name.Equals(tenantName, StringComparison.InvariantCultureIgnoreCase));
+            EntraIDTenant tenant = GetTenantConfiguration(tenantName);
             if (tenant == null) { return false; }
             string clientId = String.IsNullOrWhiteSpace(newClientId) ? tenant.ClientId : newClientId;
             return tenant.SetCredentials(clientId, newClientSecret);
@@ -426,11 +426,44 @@ namespace Yvand.EntraClaimsProvider.Configuration
                 throw new ArgumentNullException(nameof(tenantName));
             }
 
-            EntraIDTenant tenant = this.EntraIDTenants.FirstOrDefault(x => x.Name.Equals(tenantName, StringComparison.InvariantCultureIgnoreCase));
+            EntraIDTenant tenant = GetTenantConfiguration(tenantName);
             if (tenant == null) { return false; }
 
             string clientId = String.IsNullOrWhiteSpace(newClientId) ? tenant.ClientId : newClientId;
             return tenant.SetCredentials(clientId, newClientCertificatePfxFilePath, newClientCertificatePfxPassword);
+        }
+
+        /// <summary>
+        /// Gets the tenant configuration
+        /// </summary>
+        /// <param name="tenantName">Name of the tenant</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public EntraIDTenant GetTenantConfiguration(string tenantName)
+        {
+            if (String.IsNullOrWhiteSpace(tenantName))
+            {
+                throw new ArgumentNullException(nameof(tenantName));
+            }
+            return this.EntraIDTenants.FirstOrDefault(x => x.Name.Equals(tenantName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Deletes the tenant configuration
+        /// </summary>
+        /// <param name="tenantName">Name of the tenant</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public bool DeleteTenantConfiguration(string tenantName)
+        {
+            if (String.IsNullOrWhiteSpace(tenantName))
+            {
+                throw new ArgumentNullException(nameof(tenantName));
+            }
+
+            EntraIDTenant tenant = GetTenantConfiguration(tenantName);
+            if (tenant == null) { return false; }
+            return this.EntraIDTenants.Remove(tenant);
         }
 
         /// <summary>

--- a/assembly-bindings.config
+++ b/assembly-bindings.config
@@ -12,11 +12,11 @@ The content of this file may change with each version of EntraCP, make sure to u
 <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
     <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral"/>
-        <bindingRedirect oldVersion="1.37.0.0" newVersion="1.38.0.0"/>
+        <bindingRedirect oldVersion="1.39.0.0" newVersion="1.40.0.0"/>
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="1.7.10.0-1.7.11.0" newVersion="1.8.0.0"/>
+        <bindingRedirect oldVersion="1.7.10.0-1.7.11.0" newVersion="1.9.1.0"/>
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
@@ -24,7 +24,7 @@ The content of this file may change with each version of EntraCP, make sure to u
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="6.35.0.0" newVersion="7.4.1.0"/>
+        <bindingRedirect oldVersion="6.35.0.0" newVersion="7.6.0.0"/>
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>


### PR DESCRIPTION
## Changelog

* Fix an NullReferenceException in a very rare scenario where ClaimsPrincipal.Identity is null
* Add helper methods to get/delete a tenant in the configuration
* Update Azure.Identity from 1.11.2 to 1.12.0
* Update Microsoft.Graph from 5.49.0 to 5.56.0