### PR TITLE
Fix missing group members when only users members of some groups can be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for ~~AzureCP~~ EntraCP
 
+## EntraCP v27.0 - Unreleased
+
+* Ensure that all group members are retrieved when only users members of specified groups can be found in SharePoint
+* Update the script that provisions tenant with test users and groups, to be more reliable and provision 999 users (instead of 50), so tests are more realistics
+* Improve tests
+
 ## EntraCP v26.0.20240627.35 enhancements & bug-fixes - Published in June 27, 2024
 
 * Fix an NullReferenceException in a very rare scenario where ClaimsPrincipal.Identity is null

--- a/Yvand.EntraCP.Tests/BasicConfigurationTests.cs
+++ b/Yvand.EntraCP.Tests/BasicConfigurationTests.cs
@@ -20,7 +20,7 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetSomeGroups), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
         public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
@@ -33,7 +33,7 @@ namespace Yvand.EntraClaimsProvider.Tests
         //    TestSearchAndValidateForEntraIDGroup(group);
         //}
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetSomeUsers), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
         public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);

--- a/Yvand.EntraCP.Tests/BasicConfigurationTests.cs
+++ b/Yvand.EntraCP.Tests/BasicConfigurationTests.cs
@@ -20,31 +20,31 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true })]
-        public void TestAllTestGroups(EntraIdTestGroup group)
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
-        [Test]
-        public void TestRandomTestGroups([Random(0, UnitTestsHelper.TestGroupsCount - 1, 5)] int idx)
-        {
-            EntraIdTestGroup group = EntraIdTestGroupsSource.Groups[idx];
-            TestSearchAndValidateForEntraIDGroup(group);
-        }
+        //[Test]
+        //public void TestRandomTestGroups([Random(0, UnitTestsHelper.TotalNumberTestGroups - 1, 5)] int idx)
+        //{
+        //    EntraIdTestGroup group = EntraIdTestGroupsSource.Groups[idx];
+        //    TestSearchAndValidateForEntraIDGroup(group);
+        //}
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
-        public void TestAllTestUsers(EntraIdTestUser user)
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
         }
 
-        [Test]
-        public void TestRandomTestUsers([Random(0, UnitTestsHelper.TestUsersCount - 1, 5)] int idx)
-        {
-            var user = EntraIdTestUsersSource.Users[idx];
-            base.TestSearchAndValidateForEntraIDUser(user);
-        }
+        //[Test]
+        //public void TestRandomTestUsers([Random(0, UnitTestsHelper.TotalNumberTestUsers - 1, 5)] int idx)
+        //{
+        //    var user = EntraIdTestUsersSource.Users[idx];
+        //    base.TestSearchAndValidateForEntraIDUser(user);
+        //}
 
         [Test]
         [Repeat(5)]

--- a/Yvand.EntraCP.Tests/BypassDirectoryTests.cs
+++ b/Yvand.EntraCP.Tests/BypassDirectoryTests.cs
@@ -9,8 +9,8 @@ namespace Yvand.EntraClaimsProvider.Tests
     [Parallelizable(ParallelScope.Children)]
     public class BypassDirectoryOnClaimTypesTests : ClaimsProviderTestsBase
     {
-        string PrefixBypassUserSearch = "bypass-user:";
-        string PrefixBypassGroupSearch = "bypass-group:";
+        const string PrefixBypassUserSearch = "bypass-user:";
+        const string PrefixBypassGroupSearch = "bypass-group:";
         public override void InitializeSettings()
         {
             base.InitializeSettings();
@@ -26,7 +26,7 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetSomeUsers), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
         public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
@@ -36,7 +36,7 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.TestSearchAndValidateForEntraIDUser(user);
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetSomeGroups), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
         public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
@@ -45,9 +45,9 @@ namespace Yvand.EntraClaimsProvider.Tests
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
-        [TestCase("bypass-user:externalUser@contoso.com", 1, "externalUser@contoso.com")]
-        [TestCase("bypass-user:", 0, "")]
-        [TestCase("bypass-group:", 0, "")]
+        [TestCase(PrefixBypassUserSearch + "externalUser@contoso.com", 1, "externalUser@contoso.com")]
+        [TestCase(PrefixBypassUserSearch, 0, "")]
+        [TestCase(PrefixBypassGroupSearch, 0, "")]
         public void TestBypassDirectoryByClaimType(string inputValue, int expectedCount, string expectedClaimValue)
         {
             TestSearchOperation(inputValue, expectedCount, expectedClaimValue);
@@ -77,13 +77,13 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetSomeGroups), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
         public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetSomeUsers), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
         public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);

--- a/Yvand.EntraCP.Tests/BypassDirectoryTests.cs
+++ b/Yvand.EntraCP.Tests/BypassDirectoryTests.cs
@@ -26,8 +26,8 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
-        public void TestAllEntraIDUsers(EntraIdTestUser user)
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
             user.UserPrincipalName = user.DisplayName;
@@ -36,8 +36,8 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.TestSearchAndValidateForEntraIDUser(user);
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true })]
-        public void TestAllEntraIDGroups(EntraIdTestGroup group)
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
             group.Id = group.DisplayName;
@@ -77,14 +77,14 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true })]
-        public void TestAllEntraIDGroups(EntraIdTestGroup group)
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
-        public void TestAllEntraIDUsers(EntraIdTestUser user)
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
         }

--- a/Yvand.EntraCP.Tests/ClaimsProviderTestsBase.cs
+++ b/Yvand.EntraCP.Tests/ClaimsProviderTestsBase.cs
@@ -219,7 +219,7 @@ namespace Yvand.EntraClaimsProvider.Tests
         public virtual void TestAugmentationOfGoldUsersAgainstRandomGroups()
         {
             Random rnd = new Random();
-            int randomIdx = rnd.Next(0, UnitTestsHelper.TestGroupsCount - 1);
+            int randomIdx = rnd.Next(0, EntraIdTestGroupsSource.Groups.Count - 1);
             Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] TestAugmentationOfGoldUsersAgainstRandomGroups: Get group in EntraIdTestGroupsSource.Groups at index {randomIdx}.");
             EntraIdTestGroup randomGroup = null;
             try

--- a/Yvand.EntraCP.Tests/ExcludeAUserTypeTests.cs
+++ b/Yvand.EntraCP.Tests/ExcludeAUserTypeTests.cs
@@ -21,13 +21,13 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetSomeGroups), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
         public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetSomeUsers), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
         public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
@@ -60,13 +60,13 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetSomeGroups), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
         public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetSomeUsers), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
         public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
@@ -99,13 +99,13 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetSomeGroups), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
         public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetSomeUsers), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
         public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);

--- a/Yvand.EntraCP.Tests/ExcludeAUserTypeTests.cs
+++ b/Yvand.EntraCP.Tests/ExcludeAUserTypeTests.cs
@@ -21,14 +21,14 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true })]
-        public void TestAllEntraIDGroups(EntraIdTestGroup group)
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
-        public void TestAllEntraIDUsers(EntraIdTestUser user)
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
         }
@@ -60,14 +60,14 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true })]
-        public void TestAllEntraIDGroups(EntraIdTestGroup group)
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
-        public void TestAllEntraIDUsers(EntraIdTestUser user)
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
         }
@@ -99,14 +99,14 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true })]
-        public void TestAllEntraIDGroups(EntraIdTestGroup group)
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
-        public void TestAllEntraIDUsers(EntraIdTestUser user)
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
         }

--- a/Yvand.EntraCP.Tests/FilterUsersBasedOnGroupsTests.cs
+++ b/Yvand.EntraCP.Tests/FilterUsersBasedOnGroupsTests.cs
@@ -22,7 +22,7 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
         public void TestAllTestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
@@ -52,7 +52,7 @@ namespace Yvand.EntraClaimsProvider.Tests
             Random rnd = new Random();
             for (int groupsCount = 1; groupsCount <= 18; groupsCount++)
             {
-                int randomIdx = rnd.Next(0, UnitTestsHelper.TestGroupsCount - 1);
+                int randomIdx = rnd.Next(0, EntraIdTestGroupsSource.Groups.Count - 1);
                 groupIdsList.Add(EntraIdTestGroupsSource.Groups[randomIdx].Id);
             }
             Settings.RestrictSearchableUsersByGroups = String.Join(",", groupIdsList);
@@ -67,7 +67,7 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
         public void TestAllTestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);

--- a/Yvand.EntraCP.Tests/FilterUsersBasedOnGroupsTests.cs
+++ b/Yvand.EntraCP.Tests/FilterUsersBasedOnGroupsTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Yvand.EntraClaimsProvider.Tests
 {
@@ -12,7 +13,7 @@ namespace Yvand.EntraClaimsProvider.Tests
         public override void InitializeSettings()
         {
             base.InitializeSettings();
-            Settings.RestrictSearchableUsersByGroups = EntraIdTestGroupsSource.ASecurityEnabledGroup.Id;
+            Settings.RestrictSearchableUsersByGroups = EntraIdTestGroupsSource.GetSomeGroups(true, 1).ToArray()[0].Id;
             base.ApplySettings();
         }
 
@@ -22,8 +23,8 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
-        public void TestAllTestUsers(EntraIdTestUser user)
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetSomeUsers), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
         }
@@ -47,17 +48,9 @@ namespace Yvand.EntraClaimsProvider.Tests
         {
             base.InitializeSettings();
 
-            // Pick the Id of 18 (max possible) random groups, and it in property RestrictSearchableUsersByGroups
-            List<string> groupIdsList = new List<string>();
-            Random rnd = new Random();
-            for (int groupsCount = 1; groupsCount <= 18; groupsCount++)
-            {
-                int randomIdx = rnd.Next(0, EntraIdTestGroupsSource.Groups.Count - 1);
-                groupIdsList.Add(EntraIdTestGroupsSource.Groups[randomIdx].Id);
-            }
-            Settings.RestrictSearchableUsersByGroups = String.Join(",", groupIdsList);
+            // Pick the Id of 18 (max possible) random groups, and set them in property RestrictSearchableUsersByGroups
+            Settings.RestrictSearchableUsersByGroups = String.Join(",", EntraIdTestGroupsSource.GetSomeGroups(true, 18).Select(x => x.Id).ToArray());
             Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] Set property RestrictSearchableUsersByGroups: \"{Settings.RestrictSearchableUsersByGroups}\".");
-
             base.ApplySettings();
         }
 
@@ -67,8 +60,8 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
-        public void TestAllTestUsers(EntraIdTestUser user)
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetSomeUsers), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
         }
@@ -92,9 +85,7 @@ namespace Yvand.EntraClaimsProvider.Tests
         public override void InitializeSettings()
         {
             base.InitializeSettings();
-            Settings.RestrictSearchableUsersByGroups = "dbcdaf68-5949-4a15-b2f8-f385b41a9fca,72860e7b-93d5-46f7-ab56-480112f76548,461e8865-0f39-4199-86c6-0c8e25ad57ea,33780f8d-8345-4402-bc6a-d9c7e5d40d36,2c6b2fde-4f89-417a-9d8c-5e459e1520cf,7059e0ae-0cbc-4f4d-9d87-fef7289a7f50,dbcdaf68-5949-4a15-b2f8-f385b41a9fca,3cc758d6-7198-470f-878a-e5cd41a35e02,b05ddc92-b639-4ba2-95b3-9fdbc1bff2f2,40a7290c-9b67-4b7c-98ff-0c9871544423,71aa60d9-c4d1-4eaf-b398-3099b12afd88,0f51d30e-e03c-44ea-8d13-df0ca0df7a16,0f51d30e-e03c-44ea-8d13-df0ca0df7a16,982369ed-e88f-4b21-9b89-29067a0fa326,a40d2ded-2ab0-463f-b000-b3351ca6341d,ce5a4725-e719-4c2d-89bc-1c356facde99,de600b84-29aa-470c-b6ca-1459591728fb,152456d1-73a0-46d6-ac02-0403f2b5593e";
-            Settings.RestrictSearchableUsersByGroups = "db41d655-d796-43fb-9e23-351ee8b5bdb0,461e8865-0f39-4199-86c6-0c8e25ad57ea,21dd6198-c447-48dd-9ea8-347f804c4dec,dcf1e533-6d55-4b00-9788-f0d81e287c8a,21dd6198-c447-48dd-9ea8-347f804c4dec,719006f9-8eb0-48fd-8f95-556f07b0123b,d6896744-f16b-4802-9f13-0e2c9fa06274,dcf1e533-6d55-4b00-9788-f0d81e287c8a,2ae8ff19-0e4f-45cc-98ea-84f1c53e60f2,bea2607f-513a-4324-a6a1-620ee1c0ced4,bcd82b83-97c5-4c1c-9cce-58643a286298,34fe3af4-7ed9-4b5e-a64e-c0b230d5dfb4,136f71a2-c57c-4a3f-8aec-4d694e442b87,dbf5a5c3-5f51-42d6-a519-258c76960f75,33780f8d-8345-4402-bc6a-d9c7e5d40d36,a40d2ded-2ab0-463f-b000-b3351ca6341d,21dd6198-c447-48dd-9ea8-347f804c4dec,34fe3af4-7ed9-4b5e-a64e-c0b230d5dfb4";
-            Settings.RestrictSearchableUsersByGroups = "71aa60d9-c4d1-4eaf-b398-3099b12afd88,56e7a2e2-f565-450e-94cd-0d7d314217d1,c9a94341-89b5-4109-a501-2a14027b5bf0,8962bad6-ceca-43ff-a4be-9258ff81af2f,36d78c5a-80f2-4f3d-8f37-3a347d000d56,152456d1-73a0-46d6-ac02-0403f2b5593e,d6896744-f16b-4802-9f13-0e2c9fa06274,de600b84-29aa-470c-b6ca-1459591728fb,d51f225f-b484-4898-b425-5d48553aad16,36d78c5a-80f2-4f3d-8f37-3a347d000d56,0f51d30e-e03c-44ea-8d13-df0ca0df7a16,1eb5e51e-0bea-40c3-9ffb-0b85dbe2f9bf,dcf1e533-6d55-4b00-9788-f0d81e287c8a,c9a94341-89b5-4109-a501-2a14027b5bf0,3cc758d6-7198-470f-878a-e5cd41a35e02,dcf1e533-6d55-4b00-9788-f0d81e287c8a,21dd6198-c447-48dd-9ea8-347f804c4dec,253fe6d4-8e07-49a1-8a74-143d265eefbe";
+            Settings.RestrictSearchableUsersByGroups = String.Join(",", EntraIdTestGroupsSource.GetSomeGroups(true, 18).Select(x => x.Id).ToArray());
             Trace.TraceInformation($"{DateTime.Now:s} [{this.GetType().Name}] Set property RestrictSearchableUsersByGroups: \"{Settings.RestrictSearchableUsersByGroups}\".");
             base.ApplySettings();
         }

--- a/Yvand.EntraCP.Tests/GuestAccountsUPNTests.cs
+++ b/Yvand.EntraCP.Tests/GuestAccountsUPNTests.cs
@@ -24,14 +24,14 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true })]
-        public void TestAllEntraIDGroups(EntraIdTestGroup group)
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
-        public void TestAllEntraIDUsers(EntraIdTestUser user)
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);
         }

--- a/Yvand.EntraCP.Tests/GuestAccountsUPNTests.cs
+++ b/Yvand.EntraCP.Tests/GuestAccountsUPNTests.cs
@@ -24,13 +24,13 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetSomeGroups), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
         public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetSomeUsers), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
         public void TestUsers(EntraIdTestUser user)
         {
             base.TestSearchAndValidateForEntraIDUser(user);

--- a/Yvand.EntraCP.Tests/RequireExactMatchTests.cs
+++ b/Yvand.EntraCP.Tests/RequireExactMatchTests.cs
@@ -21,7 +21,7 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetSomeUsers), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
         public void TestUsers(EntraIdTestUser user)
         {
             // Input is not the full UPN value: it should not return any result

--- a/Yvand.EntraCP.Tests/RequireExactMatchTests.cs
+++ b/Yvand.EntraCP.Tests/RequireExactMatchTests.cs
@@ -21,8 +21,8 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), null)]
-        public void TestAllEntraIDUsers(EntraIdTestUser user)
+        [Test, TestCaseSource(typeof(EntraIdTestUsersSource), nameof(EntraIdTestUsersSource.GetTestData), new object[] { UnitTestsHelper.MaxNumberOfUsersToTest })]
+        public void TestUsers(EntraIdTestUser user)
         {
             // Input is not the full UPN value: it should not return any result
             TestSearchOperation(user.UserPrincipalName.Substring(0, 5), 0, String.Empty);

--- a/Yvand.EntraCP.Tests/SecurityEnabledGroupsTests.cs
+++ b/Yvand.EntraCP.Tests/SecurityEnabledGroupsTests.cs
@@ -24,7 +24,7 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetSomeGroups), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
         public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
@@ -57,7 +57,7 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetSomeGroups), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
         public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);

--- a/Yvand.EntraCP.Tests/SecurityEnabledGroupsTests.cs
+++ b/Yvand.EntraCP.Tests/SecurityEnabledGroupsTests.cs
@@ -24,8 +24,8 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true })]
-        public void TestAllEntraIDGroups(EntraIdTestGroup group)
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }
@@ -57,8 +57,8 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true })]
-        public void TestAllEntraIDGroups(EntraIdTestGroup group)
+        [Test, TestCaseSource(typeof(EntraIdTestGroupsSource), nameof(EntraIdTestGroupsSource.GetTestData), new object[] { true, UnitTestsHelper.MaxNumberOfGroupsToTest })]
+        public void TestGroups(EntraIdTestGroup group)
         {
             TestSearchAndValidateForEntraIDGroup(group);
         }

--- a/Yvand.EntraCP.Tests/Setup/Populate-EntraIDTenant.ps1
+++ b/Yvand.EntraCP.Tests/Setup/Populate-EntraIDTenant.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules Microsoft.Graph.Identity.SignIns, Microsoft.Graph.Users
+#Requires -Modules Microsoft.Graph.Authentication, Microsoft.Graph.Identity.DirectoryManagement, Microsoft.Graph.Identity.SignIns, Microsoft.Graph.Users, Microsoft.Graph.Groups
 
 <#
 .SYNOPSIS
@@ -94,7 +94,7 @@ $passwordProfile = @{
 }
 
 # Bulk add users
-$totalUsers = 50
+$totalUsers = 1000
 for ($i = 1; $i -le $totalUsers; $i++) {
     $accountName = "$($memberUsersNamePrefix)$("{0:D3}" -f $i)"
     $userPrincipalName = "$($accountName)@$($tenantName)"
@@ -124,7 +124,7 @@ foreach ($guestUser in $guestUsersList) {
 }
 
 # groups
-$allMemberUsersInEntra = Get-MgUser -ConsistencyLevel eventual -Count userCount -Filter "startsWith(DisplayName, '$($memberUsersNamePrefix)')" -OrderBy UserPrincipalName
+$allMemberUsersInEntra = Get-MgUser -ConsistencyLevel eventual -Count userCount -Filter "startsWith(DisplayName, '$($memberUsersNamePrefix)')" -OrderBy UserPrincipalName -Top $totalUsers
 $usersMemberOfAllGroups = [System.Linq.Enumerable]::Where($usersWithSpecificSettings, [Func[object, bool]] { param($x) $x.IsMemberOfAllGroups -eq $true })
 
 # Bulk add groups

--- a/Yvand.EntraCP.Tests/UnitTestsHelper.cs
+++ b/Yvand.EntraCP.Tests/UnitTestsHelper.cs
@@ -37,8 +37,6 @@ namespace Yvand.EntraClaimsProvider.Tests
         public static string DataFile_EntraId_TestGroups => TestContext.Parameters["DataFile_EntraId_TestGroups"];
         public static string TestUsersAccountNamePrefix => TestContext.Parameters["UserAccountNamePrefix"];
         public static string TestGroupsAccountNamePrefix => TestContext.Parameters["GroupAccountNamePrefix"];
-        //public const int TotalNumberTestUsers = 999 + 3; // 999 members + 3 guests
-        //public const int TotalNumberTestGroups = 50;
         public const int MaxNumberOfUsersToTest = 100;
         public const int MaxNumberOfGroupsToTest = 100;
         static TextWriterTraceListener Logger { get; set; }
@@ -229,9 +227,6 @@ namespace Yvand.EntraClaimsProvider.Tests
 
         private static Random RandomNumber = new Random();
 
-        public static EntraIdTestGroup ASecurityEnabledGroup => Groups.First(x => x.SecurityEnabled);
-        public static EntraIdTestGroup ANonSecurityEnabledGroup => Groups.First(x => !x.SecurityEnabled);
-
         private static object _LockInitGroupsSettingsList = new object();
         private static List<EntraIdTestGroupSettings> _GroupsSettings;
         public static List<EntraIdTestGroupSettings> GroupsSettings
@@ -282,8 +277,13 @@ namespace Yvand.EntraClaimsProvider.Tests
             }
         }
 
-        public static IEnumerable<EntraIdTestGroup> GetTestData(bool securityEnabledGroupsOnly, int count)
+        public static IEnumerable<EntraIdTestGroup> GetSomeGroups(bool securityEnabledGroupsOnly, int count)
         {
+            if (count > Groups.Count)
+            {
+                count = Groups.Count;
+            }
+
             List<int> userIdxs = new List<int>(count);
             for (int i = 0; i < count; i++)
             {
@@ -391,8 +391,13 @@ namespace Yvand.EntraClaimsProvider.Tests
             }
         }
 
-        public static IEnumerable<EntraIdTestUser> GetTestData(int count)
+        public static IEnumerable<EntraIdTestUser> GetSomeUsers(int count)
         {
+            if (count > Users.Count)
+            {
+                count = Users.Count;
+            }
+
             List<int> userIdxs = new List<int>(count);
             for (int i = 0; i < count; i++)
             {

--- a/Yvand.EntraCP.Tests/UnitTestsHelper.cs
+++ b/Yvand.EntraCP.Tests/UnitTestsHelper.cs
@@ -2,6 +2,7 @@
 using Microsoft.SharePoint;
 using Microsoft.SharePoint.Administration;
 using Microsoft.SharePoint.Administration.Claims;
+using Microsoft.Web.Hosting.Administration;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
@@ -36,8 +37,10 @@ namespace Yvand.EntraClaimsProvider.Tests
         public static string DataFile_EntraId_TestGroups => TestContext.Parameters["DataFile_EntraId_TestGroups"];
         public static string TestUsersAccountNamePrefix => TestContext.Parameters["UserAccountNamePrefix"];
         public static string TestGroupsAccountNamePrefix => TestContext.Parameters["GroupAccountNamePrefix"];
-        public const int TestUsersCount = 50 + 3; // 50 members + 3 guests
-        public const int TestGroupsCount = 50;
+        //public const int TotalNumberTestUsers = 999 + 3; // 999 members + 3 guests
+        //public const int TotalNumberTestGroups = 50;
+        public const int MaxNumberOfUsersToTest = 100;
+        public const int MaxNumberOfGroupsToTest = 100;
         static TextWriterTraceListener Logger { get; set; }
         public static EntraIDProviderConfiguration PersistedConfiguration;
         private static IEntraIDProviderSettings OriginalSettings;
@@ -213,7 +216,7 @@ namespace Yvand.EntraClaimsProvider.Tests
                 {
                     if (_Groups != null) { return _Groups; }
                     _Groups = new List<EntraIdTestGroup>();
-                    foreach (EntraIdTestGroup group in GetTestData(false))
+                    foreach (EntraIdTestGroup group in ReadDataSource(false))
                     {
                         _Groups.Add(group);
                     }
@@ -223,6 +226,8 @@ namespace Yvand.EntraClaimsProvider.Tests
                 }
             }
         }
+
+        private static Random RandomNumber = new Random();
 
         public static EntraIdTestGroup ASecurityEnabledGroup => Groups.First(x => x.SecurityEnabled);
         public static EntraIdTestGroup ANonSecurityEnabledGroup => Groups.First(x => !x.SecurityEnabled);
@@ -258,7 +263,7 @@ namespace Yvand.EntraClaimsProvider.Tests
             }
         }
 
-        public static IEnumerable<EntraIdTestGroup> GetTestData(bool securityEnabledGroupsOnly = false)
+        private static IEnumerable<EntraIdTestGroup> ReadDataSource(bool securityEnabledGroupsOnly = false)
         {
             string csvPath = UnitTestsHelper.DataFile_EntraId_TestGroups;
             DataTable dt = DataTable.New.ReadCsv(csvPath);
@@ -274,6 +279,20 @@ namespace Yvand.EntraClaimsProvider.Tests
                     continue;
                 }
                 yield return registrationData;
+            }
+        }
+
+        public static IEnumerable<EntraIdTestGroup> GetTestData(bool securityEnabledGroupsOnly, int count)
+        {
+            List<int> userIdxs = new List<int>(count);
+            for (int i = 0; i < count; i++)
+            {
+                userIdxs.Add(RandomNumber.Next(0, Groups.Count - 1));
+            }
+
+            foreach (int userIdx in userIdxs)
+            {
+                yield return Groups[userIdx];
             }
         }
     }
@@ -313,7 +332,7 @@ namespace Yvand.EntraClaimsProvider.Tests
                 {
                     if (_Users != null) { return _Users; }
                     _Users = new List<EntraIdTestUser>();
-                    foreach (EntraIdTestUser user in GetTestData())
+                    foreach (EntraIdTestUser user in ReadDataSource())
                     {
                         _Users.Add(user);
                     }
@@ -323,6 +342,8 @@ namespace Yvand.EntraClaimsProvider.Tests
                 }
             }
         }
+
+        private static Random RandomNumber = new Random();
 
         public static EntraIdTestUser AGuestUser => Users.FirstOrDefault(x => x.UserType == UserType.Guest);
         public static IEnumerable<EntraIdTestUser> AllGuestUsers => Users.Where(x => x.UserType == UserType.Guest);
@@ -353,7 +374,7 @@ namespace Yvand.EntraClaimsProvider.Tests
             }
         }
 
-        public static IEnumerable<EntraIdTestUser> GetTestData()
+        private static IEnumerable<EntraIdTestUser> ReadDataSource()
         {
             string csvPath = UnitTestsHelper.DataFile_EntraId_TestUsers;
             DataTable dt = DataTable.New.ReadCsv(csvPath);
@@ -367,6 +388,20 @@ namespace Yvand.EntraClaimsProvider.Tests
                 registrationData.Mail = row["mail"];
                 registrationData.GivenName = row["givenName"];
                 yield return registrationData;
+            }
+        }
+
+        public static IEnumerable<EntraIdTestUser> GetTestData(int count)
+        {
+            List<int> userIdxs = new List<int>(count);
+            for (int i = 0; i < count; i++)
+            {
+                userIdxs.Add(RandomNumber.Next(0, Users.Count - 1));
+            }
+
+            foreach (int userIdx in userIdxs)
+            {
+                yield return Users[userIdx];
             }
         }
     }

--- a/Yvand.EntraCP.Tests/UnitTestsHelper.cs
+++ b/Yvand.EntraCP.Tests/UnitTestsHelper.cs
@@ -187,12 +187,17 @@ namespace Yvand.EntraClaimsProvider.Tests
         }
     }
 
-    public class EntraIdTestGroup
+    public class EntraIdTestGroup : ICloneable
     {
         public string Id;
         public string DisplayName;
         public string GroupType;
         public bool SecurityEnabled = true;
+
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
     }
 
     public class EntraIdTestGroupSettings : EntraIdTestGroup
@@ -292,7 +297,7 @@ namespace Yvand.EntraClaimsProvider.Tests
 
             foreach (int userIdx in userIdxs)
             {
-                yield return Groups[userIdx];
+                yield return Groups[userIdx].Clone() as EntraIdTestGroup;
             }
         }
     }
@@ -303,7 +308,7 @@ namespace Yvand.EntraClaimsProvider.Tests
         Guest
     }
 
-    public class EntraIdTestUser
+    public class EntraIdTestUser : ICloneable
     {
         public string Id;
         public string DisplayName;
@@ -311,6 +316,11 @@ namespace Yvand.EntraClaimsProvider.Tests
         public UserType UserType;
         public string Mail;
         public string GivenName;
+
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
     }
 
     public class EntraIdTestUserSettings : EntraIdTestUser
@@ -406,7 +416,7 @@ namespace Yvand.EntraClaimsProvider.Tests
 
             foreach (int userIdx in userIdxs)
             {
-                yield return Users[userIdx];
+                yield return Users[userIdx].Clone() as EntraIdTestUser;
             }
         }
     }

--- a/Yvand.EntraCP.Tests/UnitTestsHelper.cs
+++ b/Yvand.EntraCP.Tests/UnitTestsHelper.cs
@@ -202,12 +202,13 @@ namespace Yvand.EntraClaimsProvider.Tests
     public class EntraIdTestGroupsSource
     {
         private static object _LockInitGroupsList = new object();
+        private static bool listInitialized = false;
         private static List<EntraIdTestGroup> _Groups;
         public static List<EntraIdTestGroup> Groups
         {
             get
             {
-                if (_Groups != null) { return _Groups; }
+                if (listInitialized) { return _Groups; }
                 lock (_LockInitGroupsList)
                 {
                     if (_Groups != null) { return _Groups; }
@@ -216,6 +217,7 @@ namespace Yvand.EntraClaimsProvider.Tests
                     {
                         _Groups.Add(group);
                     }
+                    listInitialized = true;
                     Trace.TraceInformation($"{DateTime.Now:s} [{typeof(EntraIdTestGroupsSource).Name}] Initialized List of {nameof(Groups)} with {_Groups.Count} items.");
                     return _Groups;
                 }
@@ -300,12 +302,13 @@ namespace Yvand.EntraClaimsProvider.Tests
     public class EntraIdTestUsersSource
     {
         private static object _LockInitList = new object();
+        private static bool listInitialized = false;
         private static List<EntraIdTestUser> _Users;
         public static List<EntraIdTestUser> Users
         {
             get
             {
-                if (_Users != null) { return _Users; }
+                if (listInitialized) { return _Users; }
                 lock (_LockInitList)
                 {
                     if (_Users != null) { return _Users; }
@@ -314,6 +317,7 @@ namespace Yvand.EntraClaimsProvider.Tests
                     {
                         _Users.Add(user);
                     }
+                    listInitialized = true;
                     Trace.TraceInformation($"{DateTime.Now:s} [{typeof(EntraIdTestUsersSource).Name}] Initialized List of {nameof(Users)} with {_Users.Count} items.");
                     return _Users;
                 }

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
@@ -486,6 +486,8 @@ namespace Yvand.EntraClaimsProvider
                                     conf.QueryParameters = new Microsoft.Graph.Groups.Item.Members.GraphUser.GraphUserRequestBuilder.GraphUserRequestBuilderGetQueryParameters
                                     {
                                         Select = new string[] { "Id" },
+                                        // max items count per page is 999: https://learn.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0&tabs=http#optional-query-parameters
+                                        Top = 999,
                                     };
                                     conf.Options = new List<IRequestOption>
                                     {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
@@ -461,11 +461,11 @@ namespace Yvand.EntraClaimsProvider
                     }
 
                     // List of groups that users must be member of, to be returned to SharePoint
-                    string[] restrictSearchableUsersByGroupsRequestsId = null;
-                    string restrictSearchableUsersByGroups = this.Settings.RestrictSearchableUsersByGroups;
+                    string[] allowedGroupMembersOfGroupsRequestsId = null;
+                    string allowedGroupsIDs = this.Settings.RestrictSearchableUsersByGroups;
                     //restrictSearchableUsersByGroups = "c9a94341-89b5-4109-a501-2a14027b5bf0"; // testEntraCPGroup_005 - everyone member
                     //restrictSearchableUsersByGroups = "cd5f135c-9fe5-4ec2-90d9-114e9ad2e236"; // testEntraCPGroup_004 - testEntraCPUser_001 and testEntraCPUser_010 members
-                    if (!String.IsNullOrWhiteSpace(restrictSearchableUsersByGroups) && cachedTenantData.SearchableUsersId == null)
+                    if (!String.IsNullOrWhiteSpace(allowedGroupsIDs) && cachedTenantData.SearchableUsersId == null)
                     {
                         await cachedTenantData.WriteDataLock.WaitAsync().ConfigureAwait(false);
                         lockToWriteInCachedDataWasTaken = true;
@@ -476,25 +476,25 @@ namespace Yvand.EntraClaimsProvider
                         }
                         else
                         {
-                            string[] groupsId = restrictSearchableUsersByGroups.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                            restrictSearchableUsersByGroupsRequestsId = new string[groupsId.Length];
+                            string[] groupsId = allowedGroupsIDs.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                            allowedGroupMembersOfGroupsRequestsId = new string[groupsId.Length];
                             int groupIdx = 0;
-                            foreach (string groupId in groupsId)
+                            foreach (string allowedGroupId in groupsId)
                             {
-                                RequestInformation usersMembersOfGroupRequest = tenant.GraphService.Groups[groupId].Members.GraphUser.ToGetRequestInformation(conf =>
+                                RequestInformation allowedGroupMembersRequest = tenant.GraphService.Groups[allowedGroupId].Members.GraphUser.ToGetRequestInformation(conf =>
                                 {
                                     conf.QueryParameters = new Microsoft.Graph.Groups.Item.Members.GraphUser.GraphUserRequestBuilder.GraphUserRequestBuilderGetQueryParameters
                                     {
                                         Select = new string[] { "Id" },
                                         // max items count per page is 999: https://learn.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0&tabs=http#optional-query-parameters
-                                        Top = 999,
+                                        Top = 100,
                                     };
                                     conf.Options = new List<IRequestOption>
                                     {
                                         retryHandlerOption,
                                     };
                                 });
-                                restrictSearchableUsersByGroupsRequestsId[groupIdx] = await batchRequestContent.AddBatchRequestStepAsync(usersMembersOfGroupRequest).ConfigureAwait(false);
+                                allowedGroupMembersOfGroupsRequestsId[groupIdx] = await batchRequestContent.AddBatchRequestStepAsync(allowedGroupMembersRequest).ConfigureAwait(false);
                                 groupIdx++;
                             }
                         }
@@ -534,28 +534,39 @@ namespace Yvand.EntraClaimsProvider
                         }
                     }
 
-                    if (restrictSearchableUsersByGroupsRequestsId != null)
+                    if (allowedGroupMembersOfGroupsRequestsId != null)
                     {
                         // only need 1 list that contains unique user ids
                         cachedTenantData.SearchableUsersId = new List<string>();
-                        foreach (string restrictSearchableUsersByGroupsRequestId in restrictSearchableUsersByGroupsRequestsId)
+                        foreach (string allowedGroupMembersOfGroupRequestId in allowedGroupMembersOfGroupsRequestsId)
                         {
-                            HttpStatusCode restrictSearchableUsersByGroupsResponseStatus;
-                            UserCollectionResponse restrictSearchableUsersByGroupsResponse = null;
-                            if (requestsStatusInBatchResponse.TryGetValue(restrictSearchableUsersByGroupsRequestId, out restrictSearchableUsersByGroupsResponseStatus))
+                            HttpStatusCode allowedGroupMembersOfGroupResponseStatus;
+                            //UserCollectionResponse restrictSearchableUsersByGroupsResponse = null;
+                            if (requestsStatusInBatchResponse.TryGetValue(allowedGroupMembersOfGroupRequestId, out allowedGroupMembersOfGroupResponseStatus))
                             {
-                                if (restrictSearchableUsersByGroupsResponseStatus == HttpStatusCode.OK)
+                                if (allowedGroupMembersOfGroupResponseStatus == HttpStatusCode.OK)
                                 {
-                                    restrictSearchableUsersByGroupsResponse = await batchResponse.GetResponseByIdAsync<UserCollectionResponse>(restrictSearchableUsersByGroupsRequestId).ConfigureAwait(false);
-                                    cachedTenantData.SearchableUsersId.AddRange(restrictSearchableUsersByGroupsResponse.Value.Where(x => !cachedTenantData.SearchableUsersId.Contains(x.Id)).Select(x => x.Id).ToList());
+                                    UserCollectionResponse allowedGroupMembersOfGroupResponse = await batchResponse.GetResponseByIdAsync<UserCollectionResponse>(allowedGroupMembersOfGroupRequestId).ConfigureAwait(false);
+                                    PageIterator<User, UserCollectionResponse> allowedGroupMembersPageIterator = PageIterator<User, UserCollectionResponse>.CreatePageIterator(
+                                        tenant.GraphService,
+                                        allowedGroupMembersOfGroupResponse,
+                                        (user) =>
+                                        {
+                                            if (!cachedTenantData.SearchableUsersId.Contains(user.Id))
+                                            {
+                                                cachedTenantData.SearchableUsersId.Add(user.Id);
+                                            }
+                                            return true;
+                                        });
+                                    await allowedGroupMembersPageIterator.IterateAsync().ConfigureAwait(false);
                                 }
-                                else if (restrictSearchableUsersByGroupsResponseStatus == HttpStatusCode.NotFound)
+                                else if (allowedGroupMembersOfGroupResponseStatus == HttpStatusCode.NotFound)
                                 {
                                     Logger.Log($"[{ClaimsProviderName}] Request inside the batch to get the members of a group on tenant \"{tenant.Name}\" returned nothing (the group was not found).", TraceSeverity.Verbose, EventSeverity.Information, TraceCategory.Lookup);
                                 }
                                 else
                                 {
-                                    Logger.Log($"[{ClaimsProviderName}] Request inside the batch to get the members of a group on tenant \"{tenant.Name}\" returned unexpected status '{restrictSearchableUsersByGroupsResponseStatus}'", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Lookup);
+                                    Logger.Log($"[{ClaimsProviderName}] Request inside the batch to get the members of a group on tenant \"{tenant.Name}\" returned unexpected status '{allowedGroupMembersOfGroupResponseStatus}'", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Lookup);
                                 }
                             }
                         }


### PR DESCRIPTION
## CHANGELOG

* Ensure that all group members are retrieved when only users members of specified groups can be found in SharePoint
* Update the script that provisions tenant with test users and groups, to be more reliable and provision 999 users (instead of 50), so tests are more realistics
* Improve tests