### PR TITLE
add explicit ref to System.Text.Json 6.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for ~~AzureCP~~ EntraCP
 
+## EntraCP v28.0 - enhancements & bug-fixes - Unreleased
+
+* Address [security advisory CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4) by adding an explicit reference to System.Text.Json 6.0.11 (as a quick remediation)
+
 ## EntraCP v27.0.20240820.36 - enhancements & bug-fixes - Published in August 21, 2024
 
 * Ensure that restrict searchable users feature works for all members, instead of only 100 members maximum - https://github.com/Yvand/EntraCP/issues/264

--- a/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
+++ b/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
@@ -74,10 +74,10 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
-      <Version>4.1.0</Version>
+      <Version>4.2.2</Version>
     </PackageReference>
     <PackageReference Include="NUnit.Analyzers">
-      <Version>4.3.0</Version>
+      <Version>4.4.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Yvand.EntraCP/Yvand.EntraCP.csproj
+++ b/Yvand.EntraCP/Yvand.EntraCP.csproj
@@ -59,6 +59,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json">
+      <Version>6.0.11</Version>
+    </PackageReference>
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>

--- a/assembly-bindings.config
+++ b/assembly-bindings.config
@@ -28,7 +28,7 @@ The content of this file may change with each version of EntraCP, make sure to u
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="4.0.1.2" newVersion="6.0.0.0"/>
+        <bindingRedirect oldVersion="4.0.1.2-6.0.0.0" newVersion="6.0.0.11"/>
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>


### PR DESCRIPTION
## CHANGELOG

* Address [security advisory CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4) by adding an explicit reference to System.Text.Json 6.0.11 (as a quick remediation)