### PR TITLE
Address security advisory CVE-2024-43485

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for ~~AzureCP~~ EntraCP
 
+## EntraCP v28.0 - enhancements & bug-fixes - Unreleased
+
+* Address security advisory CVE-2024-43485 (related to `System.Text.Json` 6.0.0) by bumping dependencies `Azure.Identity` and `Microsoft.Graph` to their latest version
+
 ## EntraCP v27.0.20240820.36 - enhancements & bug-fixes - Published in August 21, 2024
 
 * Ensure that restrict searchable users feature works for all members, instead of only 100 members maximum - https://github.com/Yvand/EntraCP/issues/264

--- a/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
+++ b/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
@@ -74,10 +74,10 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
-      <Version>4.1.0</Version>
+      <Version>4.2.2</Version>
     </PackageReference>
     <PackageReference Include="NUnit.Analyzers">
-      <Version>4.3.0</Version>
+      <Version>4.4.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Yvand.EntraCP/Package/Package.package
+++ b/Yvand.EntraCP/Package/Package.package
@@ -4,6 +4,7 @@
     <customAssembly location="Azure.Core.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Azure.Core.dll" />
     <customAssembly location="Azure.Identity.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Azure.Identity.dll" />
     <customAssembly location="Microsoft.Bcl.AsyncInterfaces.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Bcl.AsyncInterfaces.dll" />
+    <customAssembly location="Microsoft.Bcl.TimeProvider.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Bcl.TimeProvider.dll" />
     <customAssembly location="Microsoft.Graph.Core.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Graph.Core.dll" />
     <customAssembly location="Microsoft.Graph.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Graph.dll" />
     <customAssembly location="Microsoft.Identity.Client.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Identity.Client.dll" />
@@ -14,6 +15,7 @@
     <customAssembly location="Microsoft.IdentityModel.Protocols.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.IdentityModel.Protocols.dll" />
     <customAssembly location="Microsoft.IdentityModel.Protocols.OpenIdConnect.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll" />
     <customAssembly location="Microsoft.IdentityModel.Tokens.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.IdentityModel.Tokens.dll" />
+    <customAssembly location="Microsoft.IdentityModel.Validators.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.IdentityModel.Validators.dll" />
     <customAssembly location="Microsoft.Kiota.Abstractions.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Kiota.Abstractions.dll" />
     <customAssembly location="Microsoft.Kiota.Authentication.Azure.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Kiota.Authentication.Azure.dll" />
     <customAssembly location="Microsoft.Kiota.Http.HttpClientLibrary.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Kiota.Http.HttpClientLibrary.dll" />

--- a/Yvand.EntraCP/Yvand.EntraCP.csproj
+++ b/Yvand.EntraCP/Yvand.EntraCP.csproj
@@ -129,10 +129,10 @@
   <!-- NuGet packages -->
   <ItemGroup>
     <PackageReference Include="Azure.Identity">
-      <Version>1.12.0</Version>
+      <Version>1.13.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph">
-      <Version>5.56.0</Version>
+      <Version>5.63.0</Version>
     </PackageReference>
     <PackageReference Include="StrongNamer">
       <Version>0.2.5</Version>
@@ -166,6 +166,7 @@
 copy /Y "$(TargetDir)Azure.Core.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Azure.Identity.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Bcl.AsyncInterfaces.dll" $(ProjectDir)\bin
+copy /Y "$(TargetDir)Microsoft.Bcl.TimeProvider.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Graph.Core.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Graph.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Identity.Client.dll" $(ProjectDir)\bin
@@ -176,6 +177,7 @@ copy /Y "$(TargetDir)Microsoft.IdentityModel.Logging.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.IdentityModel.Protocols.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.IdentityModel.Protocols.OpenIdConnect.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.IdentityModel.Tokens.dll" $(ProjectDir)\bin
+copy /Y "$(TargetDir)Microsoft.IdentityModel.Validators.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Kiota.Abstractions.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Kiota.Authentication.Azure.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Kiota.Http.HttpClientLibrary.dll" $(ProjectDir)\bin

--- a/assembly-bindings.config
+++ b/assembly-bindings.config
@@ -2,7 +2,8 @@
 <!--
 This file contains the assembly bindings required to run EntraCP.
 
-Usage: On each SharePoint server, edit the file %systemroot%\Microsoft.NET\Framework64\v4.0.30319\Config\Machine.config 
+Usage: On each SharePoint server, edit the file:
+%systemroot%\Microsoft.NET\Framework64\v4.0.30319\Config\Machine.config
 and replace/update the default XML node <runtime /> with the whole XML node <runtime></runtime> below.
 
 The content of this file may change with each version of EntraCP, make sure to use the file corresponding to your version of EntraCP.
@@ -10,10 +11,6 @@ The content of this file may change with each version of EntraCP, make sure to u
 
 <runtime>
 <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-    <!-- <dependentAssembly> -->
-        <!-- <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral"/> -->
-        <!-- <bindingRedirect oldVersion="1.39.0.0" newVersion="1.40.0.0"/> -->
-    <!-- </dependentAssembly> -->
     <dependentAssembly>
         <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
         <bindingRedirect oldVersion="1.14.0.0" newVersion="1.15.2.0"/>

--- a/assembly-bindings.config
+++ b/assembly-bindings.config
@@ -29,17 +29,16 @@ The content of this file may change with each version of EntraCP, make sure to u
     <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
         <bindingRedirect oldVersion="6.0.0.0" newVersion="8.0.0.5"/>
-        <!-- <bindingRedirect oldVersion="6.0.0.0" newVersion="6.0.0.1"/> -->
     </dependentAssembly>
-    <!-- <dependentAssembly> -->
-        <!-- <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/> -->
-        <!-- <bindingRedirect oldVersion="4.0.1.1" newVersion="4.0.1.2"/> -->
-    <!-- </dependentAssembly> -->
-    <!-- <dependentAssembly> -->
-        <!-- <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/> -->
-        <!-- <bindingRedirect oldVersion="4.0.4.1" newVersion="6.0.0.0"/> -->
-    <!-- </dependentAssembly> -->
     <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="4.0.1.1" newVersion="4.0.1.2"/>
+    </dependentAssembly>
+    <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="4.0.4.1" newVersion="6.0.0.0"/>
+    </dependentAssembly>
+	<dependentAssembly>
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
         <bindingRedirect oldVersion="6.0.0.0" newVersion="8.0.0.0"/>
     </dependentAssembly>

--- a/assembly-bindings.config
+++ b/assembly-bindings.config
@@ -39,5 +39,9 @@ The content of this file may change with each version of EntraCP, make sure to u
         <!-- <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/> -->
         <!-- <bindingRedirect oldVersion="4.0.4.1" newVersion="6.0.0.0"/> -->
     <!-- </dependentAssembly> -->
+    <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="6.0.0.0" newVersion="8.0.0.0"/>
+    </dependentAssembly>
 </assemblyBinding>
 </runtime>

--- a/assembly-bindings.config
+++ b/assembly-bindings.config
@@ -10,13 +10,13 @@ The content of this file may change with each version of EntraCP, make sure to u
 
 <runtime>
 <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-    <dependentAssembly>
-        <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral"/>
-        <bindingRedirect oldVersion="1.39.0.0" newVersion="1.40.0.0"/>
-    </dependentAssembly>
+    <!-- <dependentAssembly> -->
+        <!-- <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral"/> -->
+        <!-- <bindingRedirect oldVersion="1.39.0.0" newVersion="1.40.0.0"/> -->
+    <!-- </dependentAssembly> -->
     <dependentAssembly>
         <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="1.7.10.0-1.7.11.0" newVersion="1.9.1.0"/>
+        <bindingRedirect oldVersion="1.14.0.0" newVersion="1.15.2.0"/>
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
@@ -24,19 +24,20 @@ The content of this file may change with each version of EntraCP, make sure to u
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="6.35.0.0" newVersion="7.6.0.0"/>
+        <bindingRedirect oldVersion="6.35.0.0" newVersion="8.2.0.0"/>
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="4.0.1.2" newVersion="6.0.0.0"/>
+        <bindingRedirect oldVersion="6.0.0.0" newVersion="8.0.0.5"/>
+        <!-- <bindingRedirect oldVersion="6.0.0.0" newVersion="6.0.0.1"/> -->
     </dependentAssembly>
-    <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="4.0.1.1" newVersion="4.0.1.2"/>
-    </dependentAssembly>
-    <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="4.0.4.1" newVersion="6.0.0.0"/>
-    </dependentAssembly>
+    <!-- <dependentAssembly> -->
+        <!-- <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/> -->
+        <!-- <bindingRedirect oldVersion="4.0.1.1" newVersion="4.0.1.2"/> -->
+    <!-- </dependentAssembly> -->
+    <!-- <dependentAssembly> -->
+        <!-- <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/> -->
+        <!-- <bindingRedirect oldVersion="4.0.4.1" newVersion="6.0.0.0"/> -->
+    <!-- </dependentAssembly> -->
 </assemblyBinding>
 </runtime>


### PR DESCRIPTION
## CHANGELOG

* Address security advisory CVE-2024-43485 (related to `System.Text.Json` 6.0.0) by bumping dependencies `Azure.Identity` and `Microsoft.Graph` to their latest version