### PR TITLE
Publish EntraCP v28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Address security advisory CVE-2024-43485 (related to `System.Text.Json` 6.0.0) by bumping dependencies `Azure.Identity` and `Microsoft.Graph` to their latest version
 * Fix a validation issue that impacted guest users, when the identifier property for guest users is the UserPrincipalName
+* Fix the noisy logs of category "Azure Identity" due to new level `LogMsalAlways`, by recording logs with level `LogMsalAlways` as `VerboseEx`
+* Remove the parameter EventSeverity in method Log(), as it can be deducted from parameter TraceSeverity
 
 ## EntraCP v27.0.20240820.36 - enhancements & bug-fixes - Published in August 21, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## EntraCP v28.0 - enhancements & bug-fixes - Unreleased
 
+* Address security advisory CVE-2024-43485 (related to `System.Text.Json` 6.0.0) by bumping dependencies `Azure.Identity` and `Microsoft.Graph` to their latest version
 * Fix a validation issue that impacted guest users, when the identifier property for guest users is the UserPrincipalName
 
 ## EntraCP v27.0.20240820.36 - enhancements & bug-fixes - Published in August 21, 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for ~~AzureCP~~ EntraCP
 
+## EntraCP v28.0 - enhancements & bug-fixes - Unreleased
+
+* Fix a validation issue that impacted guest users, when the identifier property for guest users is the UserPrincipalName
+
 ## EntraCP v27.0.20240820.36 - enhancements & bug-fixes - Published in August 21, 2024
 
 * Ensure that restrict searchable users feature works for all members, instead of only 100 members maximum - https://github.com/Yvand/EntraCP/issues/264

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log for ~~AzureCP~~ EntraCP
 
-## EntraCP v28.0 - enhancements & bug-fixes - Unreleased
+## EntraCP v28.0 - enhancements & bug-fixes - Published in December 12, 2024
 
 * Address security advisory CVE-2024-43485 (related to `System.Text.Json` 6.0.0) by bumping dependencies `Azure.Identity` and `Microsoft.Graph` to their latest version
 * Fix a validation issue that impacted guest users, when the identifier property for guest users is the UserPrincipalName

--- a/Yvand.EntraCP.Tests/BasicConfigurationTests.cs
+++ b/Yvand.EntraCP.Tests/BasicConfigurationTests.cs
@@ -39,6 +39,17 @@ namespace Yvand.EntraClaimsProvider.Tests
             base.TestSearchAndValidateForTestUser(user);
         }
 
+        [Test]
+        [Repeat(5)]
+        public void TestValidationOfGuestUser()
+        {
+            TestUser user = TestEntitySourceManager.GetOneUser(UserType.Guest);
+            // Test below must NOT validate, because DirectoryObjectPropertyForGuestUsers is mail, NOT UserPrincipalName
+            base.TestValidationOperation(UserIdentifierClaimType, user.UserPrincipalName, false);
+            // Test below must validate, because DirectoryObjectPropertyForGuestUsers is mail
+            base.TestValidationOperation(UserIdentifierClaimType, user.Mail, true);
+        }
+
         //[Test]
         //public void TestRandomUsers([Random(0, UnitTestsHelper.TotalNumberTestUsers - 1, 5)] int idx)
         //{

--- a/Yvand.EntraCP.Tests/GuestAccountsUPNTests.cs
+++ b/Yvand.EntraCP.Tests/GuestAccountsUPNTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System;
 using Yvand.EntraClaimsProvider.Configuration;
 
 namespace Yvand.EntraClaimsProvider.Tests
@@ -42,5 +43,33 @@ namespace Yvand.EntraClaimsProvider.Tests
         {
             base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
+
+        [Test]
+        [Repeat(5)]
+        public void TestAGuestUser()
+        {
+            TestUser user = TestEntitySourceManager.GetOneUser(UserType.Guest);
+            base.TestSearchAndValidateForTestUser(user);
+        }
+
+        [Test]
+        [Repeat(5)]
+        public void TestValidationOfGuestUser()
+        {
+            TestUser user = TestEntitySourceManager.GetOneUser(UserType.Guest);
+            // Test below must validate, because DirectoryObjectPropertyForGuestUsers UserPrincipalName
+            base.TestValidationOperation(UserIdentifierClaimType, user.UserPrincipalName, true);
+            // Test below must NOT validate, because DirectoryObjectPropertyForGuestUsers UserPrincipalName, NOT mail
+            base.TestValidationOperation(UserIdentifierClaimType, user.Mail, false);
+        }
+
+#if DEBUG
+        [Test]
+        public void DebugAugmentTestUser()
+        {
+            TestUser user = TestEntitySourceManager.GetOneUser(UserType.Guest);
+            base.TestAugmentationOperation(user.UserPrincipalName, user.IsMemberOfAllGroups, String.Empty);
+        }
+#endif
     }
 }

--- a/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
+++ b/Yvand.EntraCP.Tests/Yvand.EntraCP.Tests.csproj
@@ -74,10 +74,10 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
-      <Version>4.1.0</Version>
+      <Version>4.2.2</Version>
     </PackageReference>
     <PackageReference Include="NUnit.Analyzers">
-      <Version>4.3.0</Version>
+      <Version>4.4.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Yvand.EntraCP/Features/Yvand.EntraCP/Yvand.EntraCP.EventReceiver.cs
+++ b/Yvand.EntraCP/Features/Yvand.EntraCP/Yvand.EntraCP.EventReceiver.cs
@@ -39,7 +39,7 @@ namespace Yvand.EntraClaimsProvider.Administration
                 try
                 {
                     Logger svc = Logger.Local;
-                    Logger.Log($"[{EntraCP.ClaimsProviderName}] Activating farm-scoped feature for claims provider \"{EntraCP.ClaimsProviderName}\"", TraceSeverity.High, EventSeverity.Information, TraceCategory.Configuration);
+                    Logger.Log($"[{EntraCP.ClaimsProviderName}] Activating farm-scoped feature for claims provider \"{EntraCP.ClaimsProviderName}\"", TraceSeverity.High, TraceCategory.Configuration);
                     //EntraCPConfig existingConfig = EntraCPConfig.GetConfiguration(ClaimsProviderConstants.CONFIG_NAME);
                     //if (existingConfig == null)
                     //{
@@ -47,7 +47,7 @@ namespace Yvand.EntraClaimsProvider.Administration
                     //}
                     //else
                     //{
-                    //    ClaimsProviderLogging.Log($"[{EntraCP._ProviderInternalName}] Use configuration \"{ClaimsProviderConstants.CONFIG_NAME}\" found in the configuration database", TraceSeverity.High, EventSeverity.Information, ClaimsProviderLogging.TraceCategory.Configuration);
+                    //    ClaimsProviderLogging.Log($"[{EntraCP._ProviderInternalName}] Use configuration \"{ClaimsProviderConstants.CONFIG_NAME}\" found in the configuration database", TraceSeverity.High, ClaimsProviderLogging.TraceCategory.Configuration);
                     //}
                 }
                 catch (Exception ex)
@@ -63,7 +63,7 @@ namespace Yvand.EntraClaimsProvider.Administration
             {
                 try
                 {
-                    Logger.Log($"[{EntraCP.ClaimsProviderName}] Uninstalling farm-scoped feature for claims provider \"{EntraCP.ClaimsProviderName}\": Deleting configuration from the farm", TraceSeverity.High, EventSeverity.Information, TraceCategory.Configuration);
+                    Logger.Log($"[{EntraCP.ClaimsProviderName}] Uninstalling farm-scoped feature for claims provider \"{EntraCP.ClaimsProviderName}\": Deleting configuration from the farm", TraceSeverity.High, TraceCategory.Configuration);
                     //EntraCPConfig.DeleteConfiguration(ClaimsProviderConstants.CONFIG_NAME);
                     Logger.Unregister();
                 }
@@ -80,7 +80,7 @@ namespace Yvand.EntraClaimsProvider.Administration
             {
                 try
                 {
-                    Logger.Log($"[{EntraCP.ClaimsProviderName}] Deactivating farm-scoped feature for claims provider \"{EntraCP.ClaimsProviderName}\": Removing claims provider from the farm (but not its configuration)", TraceSeverity.High, EventSeverity.Information, TraceCategory.Configuration);
+                    Logger.Log($"[{EntraCP.ClaimsProviderName}] Deactivating farm-scoped feature for claims provider \"{EntraCP.ClaimsProviderName}\": Removing claims provider from the farm (but not its configuration)", TraceSeverity.High, TraceCategory.Configuration);
                     base.RemoveClaimProvider((string)EntraCP.ClaimsProviderName);
                 }
                 catch (Exception ex)

--- a/Yvand.EntraCP/Package/Package.package
+++ b/Yvand.EntraCP/Package/Package.package
@@ -4,6 +4,7 @@
     <customAssembly location="Azure.Core.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Azure.Core.dll" />
     <customAssembly location="Azure.Identity.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Azure.Identity.dll" />
     <customAssembly location="Microsoft.Bcl.AsyncInterfaces.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Bcl.AsyncInterfaces.dll" />
+    <customAssembly location="Microsoft.Bcl.TimeProvider.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Bcl.TimeProvider.dll" />
     <customAssembly location="Microsoft.Graph.Core.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Graph.Core.dll" />
     <customAssembly location="Microsoft.Graph.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Graph.dll" />
     <customAssembly location="Microsoft.Identity.Client.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Identity.Client.dll" />
@@ -14,6 +15,7 @@
     <customAssembly location="Microsoft.IdentityModel.Protocols.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.IdentityModel.Protocols.dll" />
     <customAssembly location="Microsoft.IdentityModel.Protocols.OpenIdConnect.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll" />
     <customAssembly location="Microsoft.IdentityModel.Tokens.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.IdentityModel.Tokens.dll" />
+    <customAssembly location="Microsoft.IdentityModel.Validators.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.IdentityModel.Validators.dll" />
     <customAssembly location="Microsoft.Kiota.Abstractions.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Kiota.Abstractions.dll" />
     <customAssembly location="Microsoft.Kiota.Authentication.Azure.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Kiota.Authentication.Azure.dll" />
     <customAssembly location="Microsoft.Kiota.Http.HttpClientLibrary.dll" deploymentTarget="GlobalAssemblyCache" sourcePath="bin\Microsoft.Kiota.Http.HttpClientLibrary.dll" />

--- a/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx.cs
+++ b/Yvand.EntraCP/TEMPLATE/ADMIN/EntraCP/GlobalSettings.ascx.cs
@@ -183,7 +183,7 @@ namespace Yvand.EntraClaimsProvider.Administration
             {
                 Settings.EntraIDTenants.Remove(tenantToRemove);
                 CommitChanges();
-                Logger.Log($"Microsoft Entra ID tenant '{tenantToRemove.Name}' was successfully removed from configuration '{ConfigurationName}'", TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Configuration);
+                Logger.Log($"Microsoft Entra ID tenant '{tenantToRemove.Name}' was successfully removed from configuration '{ConfigurationName}'", TraceSeverity.Medium, TraceCategory.Configuration);
                 LabelMessage.Text = String.Format(TextSummaryPersistedObjectInformation, Configuration.Name, Configuration.Version, Configuration.Id);
                 PopulateConnectionsGrid();
             }
@@ -386,7 +386,7 @@ namespace Yvand.EntraClaimsProvider.Administration
             this.Settings.EntraIDTenants.Add(newTenant);
 
             CommitChanges();
-            Logger.Log($"Microsoft Entra ID tenant '{this.TxtTenantName.Text}' was successfully added to configuration '{ConfigurationName}'", TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Configuration);
+            Logger.Log($"Microsoft Entra ID tenant '{this.TxtTenantName.Text}' was successfully added to configuration '{ConfigurationName}'", TraceSeverity.Medium, TraceCategory.Configuration);
             LabelMessage.Text = String.Format(TextSummaryPersistedObjectInformation, Configuration.Name, Configuration.Version, Configuration.Id);
 
             PopulateConnectionsGrid();

--- a/Yvand.EntraCP/Yvand.EntraCP.csproj
+++ b/Yvand.EntraCP/Yvand.EntraCP.csproj
@@ -129,10 +129,10 @@
   <!-- NuGet packages -->
   <ItemGroup>
     <PackageReference Include="Azure.Identity">
-      <Version>1.12.0</Version>
+      <Version>1.13.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph">
-      <Version>5.56.0</Version>
+      <Version>5.63.0</Version>
     </PackageReference>
     <PackageReference Include="StrongNamer">
       <Version>0.2.5</Version>
@@ -166,6 +166,7 @@
 copy /Y "$(TargetDir)Azure.Core.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Azure.Identity.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Bcl.AsyncInterfaces.dll" $(ProjectDir)\bin
+copy /Y "$(TargetDir)Microsoft.Bcl.TimeProvider.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Graph.Core.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Graph.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Identity.Client.dll" $(ProjectDir)\bin
@@ -176,6 +177,7 @@ copy /Y "$(TargetDir)Microsoft.IdentityModel.Logging.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.IdentityModel.Protocols.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.IdentityModel.Protocols.OpenIdConnect.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.IdentityModel.Tokens.dll" $(ProjectDir)\bin
+copy /Y "$(TargetDir)Microsoft.IdentityModel.Validators.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Kiota.Abstractions.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Kiota.Authentication.Azure.dll" $(ProjectDir)\bin
 copy /Y "$(TargetDir)Microsoft.Kiota.Http.HttpClientLibrary.dll" $(ProjectDir)\bin

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Administration/EntraCPUserControl.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Administration/EntraCPUserControl.cs
@@ -227,7 +227,7 @@ namespace Yvand.EntraClaimsProvider.Administration
             if (ConfigurationID == Guid.Empty) { Status |= ConfigStatus.PersistedObjectIDPropNotSet; }
             if (Status != ConfigStatus.AllGood)
             {
-                Logger.Log($"[{ClaimsProviderName}] {MostImportantError}", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Configuration);
+                Logger.Log($"[{ClaimsProviderName}] {MostImportantError}", TraceSeverity.Unexpected, TraceCategory.Configuration);
                 return Status;
             }
 
@@ -245,7 +245,7 @@ namespace Yvand.EntraClaimsProvider.Administration
 
             if (Status != ConfigStatus.AllGood)
             {
-                Logger.Log($"[{ClaimsProviderName}] {MostImportantError}", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Configuration);
+                Logger.Log($"[{ClaimsProviderName}] {MostImportantError}", TraceSeverity.Unexpected, TraceCategory.Configuration);
                 return Status;
             }
 
@@ -266,7 +266,7 @@ namespace Yvand.EntraClaimsProvider.Administration
 
             if (Status != ConfigStatus.AllGood)
             {
-                Logger.Log($"[{ClaimsProviderName}] {MostImportantError}", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Configuration);
+                Logger.Log($"[{ClaimsProviderName}] {MostImportantError}", TraceSeverity.Unexpected, TraceCategory.Configuration);
             }
             return Status;
         }

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -332,7 +332,6 @@ namespace Yvand.EntraClaimsProvider.Configuration
                 incomingEntityClaimTypeConfig,
             };
             this.ExactSearch = true;
-            this.Input = this.IncomingEntity.Value;
         }
 
         /// <summary>

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -324,7 +324,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
                !x.UseMainClaimTypeOfDirectoryObject);
             if (incomingEntityClaimTypeConfig == null)
             {
-                Logger.Log($"[{EntraCP.ClaimsProviderName}] Unable to validate entity \"{this.IncomingEntity.Value}\" because its claim type \"{this.IncomingEntity.ClaimType}\" was not found in the ClaimTypes list of current configuration.", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Configuration);
+                Logger.Log($"[{EntraCP.ClaimsProviderName}] Unable to validate entity \"{this.IncomingEntity.Value}\" because its claim type \"{this.IncomingEntity.ClaimType}\" was not found in the ClaimTypes list of current configuration.", TraceSeverity.Unexpected, TraceCategory.Configuration);
                 throw new InvalidOperationException($"[{EntraCP.ClaimsProviderName}] Unable validate entity \"{this.IncomingEntity.Value}\" because its claim type \"{this.IncomingEntity.ClaimType}\" was not found in the ClaimTypes list of current configuration.");
             }
             this.CurrentClaimTypeConfigList = new List<ClaimTypeConfig>(1)

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDProviderConfiguration.cs
@@ -128,7 +128,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
             SPTrustedLoginProvider spTrust = Utils.GetSPTrustAssociatedWithClaimsProvider(claimsProviderName);
             if (spTrust == null)
             {
-                Logger.Log($"No SPTrustedLoginProvider associated with claims provider '{claimsProviderName}' was found.", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
+                Logger.Log($"No SPTrustedLoginProvider associated with claims provider '{claimsProviderName}' was found.", TraceSeverity.Unexpected, TraceCategory.Core);
                 return null;
             }
 
@@ -473,7 +473,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
         {
             this.ValidateConfiguration();
             base.Update();
-            Logger.Log($"Successfully updated configuration '{this.Name}' with Id {this.Id}", TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
+            Logger.Log($"Successfully updated configuration '{this.Name}' with Id {this.Id}", TraceSeverity.High, TraceCategory.Core);
         }
 
         /// <summary>
@@ -484,7 +484,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
         {
             this.ValidateConfiguration();
             base.Update(ensure);
-            Logger.Log($"Successfully updated configuration '{this.Name}' with Id {this.Id}", TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
+            Logger.Log($"Successfully updated configuration '{this.Name}' with Id {this.Id}", TraceSeverity.High, TraceCategory.Core);
         }
 
         /// <summary>
@@ -581,7 +581,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
         public override void Delete()
         {
             base.Delete();
-            Logger.Log($"Successfully deleted configuration '{this.Name}' with Id {this.Id}", TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
+            Logger.Log($"Successfully deleted configuration '{this.Name}' with Id {this.Id}", TraceSeverity.High, TraceCategory.Core);
         }
 
         /// <summary>
@@ -663,7 +663,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
             ClaimTypes.Clear();
             ClaimTypes = ReturnDefaultClaimTypesConfig();
             Logger.Log($"Claim types list of configuration '{Name}' was successfully reset to default configuration",
-                TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
+                TraceSeverity.High, TraceCategory.Core);
         }
 
         /// <summary>
@@ -699,11 +699,11 @@ namespace Yvand.EntraClaimsProvider.Configuration
             EntraIDProviderConfiguration configuration = GetGlobalConfiguration(configurationId);
             if (configuration == null)
             {
-                Logger.Log($"Configuration ID '{configurationId}' was not found in configuration database", TraceSeverity.Medium, EventSeverity.Error, TraceCategory.Core);
+                Logger.Log($"Configuration ID '{configurationId}' was not found in configuration database", TraceSeverity.Medium, TraceCategory.Core);
                 return;
             }
             configuration.Delete();
-            Logger.Log($"Configuration ID '{configurationId}' was successfully deleted from configuration database", TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
+            Logger.Log($"Configuration ID '{configurationId}' was successfully deleted from configuration database", TraceSeverity.High, TraceCategory.Core);
         }
 
         /// <summary>
@@ -734,7 +734,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
                 DeleteGlobalConfiguration(configurationID);
             }
 
-            Logger.Log($"Creating configuration '{configurationName}' with Id {configurationID}...", TraceSeverity.VerboseEx, EventSeverity.Error, TraceCategory.Core);
+            Logger.Log($"Creating configuration '{configurationName}' with Id {configurationID}...", TraceSeverity.VerboseEx, TraceCategory.Core);
             //ConstructorInfo ctorWithParameters = T.GetConstructor(new[] { typeof(string), typeof(SPFarm), typeof(string) });
             //EntraIDProviderConfiguration globalConfiguration = (EntraIDProviderConfiguration)ctorWithParameters.Invoke(new object[] { configurationName, SPFarm.Local, claimsProviderName });
             //TSettings defaultSettings = globalConfiguration.GetDefaultSettings();
@@ -743,7 +743,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
             globalConfiguration.ApplySettings(defaultSettings, false);
             globalConfiguration.Id = configurationID;
             globalConfiguration.Update(true);
-            Logger.Log($"Created configuration '{configurationName}' with Id {globalConfiguration.Id}", TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
+            Logger.Log($"Created configuration '{configurationName}' with Id {globalConfiguration.Id}", TraceSeverity.High, TraceCategory.Core);
             return globalConfiguration;
         }
     }

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/EntraIDTenant.cs
@@ -178,17 +178,17 @@ namespace Yvand.EntraClaimsProvider.Configuration
         {
             if (String.IsNullOrWhiteSpace(this.ClientSecret) && this.ClientCertificateWithPrivateKey == null)
             {
-                Logger.Log($"[{EntraCP.ClaimsProviderName}] Cannot initialize authentication for tenant {this.Name} because both properties {nameof(ClientSecret)} and {nameof(ClientCertificateWithPrivateKey)} are not set.", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Configuration);
+                Logger.Log($"[{EntraCP.ClaimsProviderName}] Cannot initialize authentication for tenant {this.Name} because both properties {nameof(ClientSecret)} and {nameof(ClientCertificateWithPrivateKey)} are not set.", TraceSeverity.Unexpected, TraceCategory.Configuration);
                 return;
             }
             if (String.IsNullOrWhiteSpace(this.ClientId))
             {
-                Logger.Log($"[{EntraCP.ClaimsProviderName}] Cannot initialize authentication for tenant {this.Name} because the property {nameof(ClientId)} is not set.", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Configuration);
+                Logger.Log($"[{EntraCP.ClaimsProviderName}] Cannot initialize authentication for tenant {this.Name} because the property {nameof(ClientId)} is not set.", TraceSeverity.Unexpected, TraceCategory.Configuration);
                 return;
             }
             if (String.IsNullOrWhiteSpace(this.Name))
             {
-                Logger.Log($"[{EntraCP.ClaimsProviderName}] Cannot initialize authentication because the property {nameof(Name)} of current tenant is not set.", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Configuration);
+                Logger.Log($"[{EntraCP.ClaimsProviderName}] Cannot initialize authentication because the property {nameof(Name)} of current tenant is not set.", TraceSeverity.Unexpected, TraceCategory.Configuration);
                 return;
             }
 
@@ -250,7 +250,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
             HttpClient httpClient = GraphClientFactory.Create(handlers: handlers, proxy: webProxy, nationalCloud: cloudInstanceSettings.NameInGraphCore);
             httpClient.Timeout = TimeSpan.FromMilliseconds(requestsTimeout);
             this.GraphService = new GraphServiceClient(httpClient, tokenCredential, new[] { cloudInstanceSettings.GraphScope });
-            Logger.Log($"[{EntraCP.ClaimsProviderName}] Initialized authentication for tenant \"{this.Name}\" on cloud instance \"{cloudInstanceSettings.Name}\" (authority \"{cloudInstanceSettings.Authority}\" and scope \"{cloudInstanceSettings.GraphScope}\").", TraceSeverity.High, EventSeverity.Information, TraceCategory.Configuration);
+            Logger.Log($"[{EntraCP.ClaimsProviderName}] Initialized authentication for tenant \"{this.Name}\" on cloud instance \"{cloudInstanceSettings.Name}\" (authority \"{cloudInstanceSettings.Authority}\" and scope \"{cloudInstanceSettings.GraphScope}\").", TraceSeverity.High, TraceCategory.Configuration);
         }
 
         public async Task<bool> TestConnectionAsync(string proxyAddress)

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraCP.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraCP.cs
@@ -106,7 +106,8 @@ namespace Yvand.EntraClaimsProvider
             {
                 if (args.EventSource.Name == "Azure-Identity")
                 {
-                    Logger.Log($"[{this.Name}] {args.EventName} {message}", Utils.EventLogToTraceSeverity(args.Level), EventSeverity.Error, TraceCategory.AzureIdentity);
+                    TraceSeverity traceSeverity = Utils.EventLogToTraceSeverity(args.Level);
+                    Logger.Log($"[{this.Name}] {args.EventName} {message}", traceSeverity, TraceCategory.AzureIdentity);
                 }
             }, EventLevel.Informational);
         }
@@ -177,13 +178,13 @@ namespace Yvand.EntraClaimsProvider
                 if (settings.Version == this.SettingsVersion)
                 {
                     Logger.Log($"[{this.Name}] Local copy of settings is up to date with version {this.SettingsVersion}.",
-                    TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Core);
+                    TraceSeverity.VerboseEx, TraceCategory.Core);
                     return true;
                 }
 
                 this.Settings = ClaimsProviderSettings.GenerateFromEntraIDProviderSettings(settings);
                 Logger.Log($"[{this.Name}] Settings have new version {this.Settings.Version}, refreshing local copy",
-                    TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Core);
+                    TraceSeverity.Medium, TraceCategory.Core);
                 success = this.InitializeInternalRuntimeSettings();
                 if (success)
                 {
@@ -235,7 +236,7 @@ namespace Yvand.EntraClaimsProvider
             if (settings.ClaimTypes?.Count <= 0)
             {
                 Logger.Log($"[{this.Name}] Cannot continue because configuration has 0 claim configured.",
-                    TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
+                    TraceSeverity.Unexpected, TraceCategory.Core);
                 return false;
             }
 
@@ -273,7 +274,7 @@ namespace Yvand.EntraClaimsProvider
 
             if (!identityClaimTypeFound)
             {
-                Logger.Log($"[{this.Name}] Cannot continue because identity claim type '{this.SPTrust.IdentityClaimTypeInformation.MappedClaimType}' set in the SPTrustedIdentityTokenIssuer '{SPTrust.Name}' is missing in the ClaimTypeConfig list.", TraceSeverity.Unexpected, EventSeverity.ErrorCritical, TraceCategory.Core);
+                Logger.Log($"[{this.Name}] Cannot continue because identity claim type '{this.SPTrust.IdentityClaimTypeInformation.MappedClaimType}' set in the SPTrustedIdentityTokenIssuer '{SPTrust.Name}' is missing in the ClaimTypeConfig list.", TraceSeverity.Unexpected, TraceCategory.Core);
                 return false;
             }
 
@@ -364,7 +365,7 @@ namespace Yvand.EntraClaimsProvider
             if (loginType != SPOriginalIssuerType.TrustedProvider && loginType != SPOriginalIssuerType.ClaimProvider)
             {
                 Logger.Log($"[{Name}] Not trying to augment '{decodedEntity.Value}' because his OriginalIssuer is '{decodedEntity.OriginalIssuer}'.",
-                    TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Augmentation);
+                    TraceSeverity.VerboseEx, TraceCategory.Augmentation);
                 return;
             }
 
@@ -382,11 +383,11 @@ namespace Yvand.EntraClaimsProvider
                     if (Settings.GroupIdentifierClaimTypeConfig == null)
                     {
                         Logger.Log($"[{Name}] No claim type with EntityType 'Group' was found, please check claims mapping table.",
-                            TraceSeverity.High, EventSeverity.Error, TraceCategory.Augmentation);
+                            TraceSeverity.High, TraceCategory.Augmentation);
                         return;
                     }
 
-                    Logger.Log($"[{Name}] Starting augmentation for user '{decodedEntity.Value}'.", TraceSeverity.Verbose, EventSeverity.Information, TraceCategory.Augmentation);
+                    Logger.Log($"[{Name}] Starting augmentation for user '{decodedEntity.Value}'.", TraceSeverity.Verbose, TraceCategory.Augmentation);
                     OperationContext currentContext = new OperationContext(this.Settings as ClaimsProviderSettings, OperationType.Augmentation, null, decodedEntity, context, null, null, Int32.MaxValue);
                     Stopwatch timer = new Stopwatch();
                     timer.Start();
@@ -401,15 +402,15 @@ namespace Yvand.EntraClaimsProvider
                         {
                             claims.Add(CreateClaim(Settings.GroupIdentifierClaimTypeConfig.ClaimType, group, Settings.GroupIdentifierClaimTypeConfig.ClaimValueType));
                             Logger.Log($"[{Name}] Added group '{group}' to user '{currentContext.IncomingEntity.Value}'",
-                                TraceSeverity.Verbose, EventSeverity.Information, TraceCategory.Augmentation);
+                                TraceSeverity.Verbose, TraceCategory.Augmentation);
                         }
                         Logger.Log($"[{Name}] Augmented user '{currentContext.IncomingEntity.Value}' with {groups.Count} groups in {timer.ElapsedMilliseconds} ms",
-                            TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Augmentation);
+                            TraceSeverity.Medium, TraceCategory.Augmentation);
                     }
                     else
                     {
                         Logger.Log($"[{Name}] Got no group in {timer.ElapsedMilliseconds} ms for user '{currentContext.IncomingEntity.Value}'",
-                            TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Augmentation);
+                            TraceSeverity.Medium, TraceCategory.Augmentation);
                     }
                 }
                 catch (Exception ex)
@@ -439,9 +440,9 @@ namespace Yvand.EntraClaimsProvider
                 {
                     resolved.Add(entity);
                     Logger.Log($"[{Name}] Added entity: display text: '{entity.DisplayText}', claim value: '{entity.Claim.Value}', claim type: '{entity.Claim.ClaimType}'",
-                        TraceSeverity.Verbose, EventSeverity.Information, TraceCategory.Claims_Picking);
+                        TraceSeverity.Verbose, TraceCategory.Claims_Picking);
                 }
-                Logger.Log($"[{Name}] Returned {entities.Count} entities with value '{currentContext.Input}'", TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Claims_Picking);
+                Logger.Log($"[{Name}] Returned {entities.Count} entities with value '{currentContext.Input}'", TraceSeverity.Medium, TraceCategory.Claims_Picking);
             }
             catch (Exception ex)
             {
@@ -483,10 +484,10 @@ namespace Yvand.EntraClaimsProvider
                     }
                     matchNode.AddEntity(entity);
                     Logger.Log($"[{Name}] Added entity: display text: '{entity.DisplayText}', claim value: '{entity.Claim.Value}', claim type: '{entity.Claim.ClaimType}'",
-                        TraceSeverity.Verbose, EventSeverity.Information, TraceCategory.Claims_Picking);
+                        TraceSeverity.Verbose, TraceCategory.Claims_Picking);
                 }
                 Logger.Log($"[{Name}] Returned {entities.Count} entities from value '{currentContext.Input}'",
-                    TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Claims_Picking);
+                    TraceSeverity.Medium, TraceCategory.Claims_Picking);
             }
             catch (Exception ex)
             {
@@ -516,12 +517,12 @@ namespace Yvand.EntraClaimsProvider
                 {
                     resolved.Add(entities[0]);
                     Logger.Log($"[{Name}] Validated entity: display text: '{entities[0].DisplayText}', claim value: '{entities[0].Claim.Value}', claim type: '{entities[0].Claim.ClaimType}'",
-                        TraceSeverity.High, EventSeverity.Information, TraceCategory.Claims_Picking);
+                        TraceSeverity.High, TraceCategory.Claims_Picking);
                 }
                 else
                 {
                     int entityCount = entities == null ? 0 : entities.Count;
-                    Logger.Log($"[{Name}] Validation failed: found {entityCount.ToString()} entities instead of 1 for incoming claim with value '{currentContext.IncomingEntity.Value}' and type '{currentContext.IncomingEntity.ClaimType}'", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Claims_Picking);
+                    Logger.Log($"[{Name}] Validation failed: found {entityCount.ToString()} entities instead of 1 for incoming claim with value '{currentContext.IncomingEntity.Value}' and type '{currentContext.IncomingEntity.ClaimType}'", TraceSeverity.Unexpected, TraceCategory.Claims_Picking);
                 }
             }
             catch (Exception ex)
@@ -554,7 +555,7 @@ namespace Yvand.EntraClaimsProvider
                         currentContext.Input,
                         currentContext.CurrentClaimTypeConfigList.FindAll(x => !x.UseMainClaimTypeOfDirectoryObject));
                     Logger.Log($"[{Name}] Created {pickerEntityList.Count} entity(ies) without contacting Microsoft Entra ID tenant(s) because EntraCP property AlwaysResolveUserInput is set to true.",
-                        TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Claims_Picking);
+                        TraceSeverity.Medium, TraceCategory.Claims_Picking);
                     return pickerEntityList;
                 }
 
@@ -594,7 +595,7 @@ namespace Yvand.EntraClaimsProvider
                         {
                             PickerEntity entity = pickerEntityList.FirstOrDefault();
                             Logger.Log($"[{Name}] Created entity without contacting Microsoft Entra ID tenant(s) because value started with prefix '{ctConfigWithInputPrefixMatch.PrefixToBypassLookup}', which is configured for claim type '{ctConfigWithInputPrefixMatch.ClaimType}'. Claim value: '{entity.Claim.Value}', claim type: '{entity.Claim.ClaimType}'",
-                                TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Claims_Picking);
+                                TraceSeverity.VerboseEx, TraceCategory.Claims_Picking);
                         }
                     }
                     else
@@ -624,7 +625,7 @@ namespace Yvand.EntraClaimsProvider
                         {
                             PickerEntity entity = pickerEntityList.FirstOrDefault();
                             Logger.Log($"[{Name}] Validated entity without contacting Microsoft Entra ID tenant(s) because its claim type ('{currentContext.CurrentClaimTypeConfigList.First().ClaimType}') has property 'PrefixToBypassLookup' set in EntraCPConfig.ClaimTypes. Claim value: '{entity.Claim.Value}', claim type: '{entity.Claim.ClaimType}'",
-                                TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Claims_Picking);
+                                TraceSeverity.VerboseEx, TraceCategory.Claims_Picking);
                         }
                     }
                     else
@@ -773,7 +774,7 @@ namespace Yvand.EntraClaimsProvider
 
                 }
             }
-            Logger.Log($"[{Name}] Created {spEntities.Count} entity(ies) after filtering directory results", TraceSeverity.Verbose, EventSeverity.Information, TraceCategory.Lookup);
+            Logger.Log($"[{Name}] Created {spEntities.Count} entity(ies) after filtering directory results", TraceSeverity.Verbose, TraceCategory.Lookup);
             return spEntities;
         }
         #endregion
@@ -813,11 +814,11 @@ namespace Yvand.EntraClaimsProvider
                 {
                     entity.EntityData[ctConfig.EntityDataKey] = entityAttribValue;
                     nbMetadata++;
-                    Logger.Log($"[{Name}] Set metadata '{ctConfig.EntityDataKey}' of new entity to '{entityAttribValue}'", TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Claims_Picking);
+                    Logger.Log($"[{Name}] Set metadata '{ctConfig.EntityDataKey}' of new entity to '{entityAttribValue}'", TraceSeverity.VerboseEx, TraceCategory.Claims_Picking);
                 }
             }
 
-            Logger.Log($"[{Name}] Created entity: display text: '{entity.DisplayText}', claim value: '{entity.Claim.Value}', claim type: '{entity.Claim.ClaimType}', and filled with {nbMetadata} metadata.", TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Claims_Picking);
+            Logger.Log($"[{Name}] Created entity: display text: '{entity.DisplayText}', claim value: '{entity.Claim.Value}', claim type: '{entity.Claim.ClaimType}', and filled with {nbMetadata} metadata.", TraceSeverity.VerboseEx, TraceCategory.Claims_Picking);
             return entity;
         }
 
@@ -842,11 +843,11 @@ namespace Yvand.EntraClaimsProvider
                 if (!String.IsNullOrWhiteSpace(ctConfig.EntityDataKey))
                 {
                     entity.EntityData[ctConfig.EntityDataKey] = entity.Claim.Value;
-                    Logger.Log($"[{Name}] Added metadata '{ctConfig.EntityDataKey}' with value '{entity.EntityData[ctConfig.EntityDataKey]}' to new entity", TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Claims_Picking);
+                    Logger.Log($"[{Name}] Added metadata '{ctConfig.EntityDataKey}' with value '{entity.EntityData[ctConfig.EntityDataKey]}' to new entity", TraceSeverity.VerboseEx, TraceCategory.Claims_Picking);
                 }
 
                 entities.Add(entity);
-                Logger.Log($"[{Name}] Created entity: display text: '{entity.DisplayText}', value: '{entity.Claim.Value}', claim type: '{entity.Claim.ClaimType}'.", TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Claims_Picking);
+                Logger.Log($"[{Name}] Created entity: display text: '{entity.DisplayText}', value: '{entity.Claim.Value}', claim type: '{entity.Claim.ClaimType}'.", TraceSeverity.VerboseEx, TraceCategory.Claims_Picking);
             }
             return entities.Count > 0 ? entities : null;
         }
@@ -1028,7 +1029,7 @@ namespace Yvand.EntraClaimsProvider
                 // Since SPClaimProviderManager.IsUserIdentifierClaim() returned true, SPClaimProviderManager.DecodeUserIdentifierClaim() will work
                 SPClaim curUser = SPClaimProviderManager.DecodeUserIdentifierClaim(entity);
                 Logger.Log($"[{Name}] Returning user key for '{entity.Value}'",
-                    TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Rehydration);
+                    TraceSeverity.VerboseEx, TraceCategory.Rehydration);
                 return CreateClaim(this.SPTrust.IdentityClaimTypeInformation.MappedClaimType, curUser.Value, curUser.ValueType);
             }
             catch (Exception ex)

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/EntraIDEntityProvider.cs
@@ -150,11 +150,11 @@ namespace Yvand.EntraClaimsProvider
             }
             if (groupsInTenant != null)
             {
-                Logger.Log($"[{ClaimsProviderName}] Got {groupsInTenant.Count} groups in {timer.ElapsedMilliseconds} ms for user '{currentContext.IncomingEntity.Value}' from tenant '{tenant.Name}'", TraceSeverity.Verbose, EventSeverity.Information, TraceCategory.Augmentation);
+                Logger.Log($"[{ClaimsProviderName}] Got {groupsInTenant.Count} groups in {timer.ElapsedMilliseconds} ms for user '{currentContext.IncomingEntity.Value}' from tenant '{tenant.Name}'", TraceSeverity.Verbose, TraceCategory.Augmentation);
             }
             else
             {
-                Logger.Log($"[{ClaimsProviderName}] Got no group in {timer.ElapsedMilliseconds} ms for user '{currentContext.IncomingEntity.Value}' from tenant '{tenant.Name}'", TraceSeverity.Verbose, EventSeverity.Information, TraceCategory.Augmentation);
+                Logger.Log($"[{ClaimsProviderName}] Got no group in {timer.ElapsedMilliseconds} ms for user '{currentContext.IncomingEntity.Value}' from tenant '{tenant.Name}'", TraceSeverity.Verbose, TraceCategory.Augmentation);
             }
             return groupsInTenant;
         }
@@ -341,11 +341,11 @@ namespace Yvand.EntraClaimsProvider
                     timer.Stop();
                     if (tenantResults != null)
                     {
-                        Logger.Log($"[{ClaimsProviderName}] Got {tenantResults.Count} users/groups in {timer.ElapsedMilliseconds.ToString()} ms from '{tenant.Name}' with input '{currentContext.Input}'", TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Lookup);
+                        Logger.Log($"[{ClaimsProviderName}] Got {tenantResults.Count} users/groups in {timer.ElapsedMilliseconds.ToString()} ms from '{tenant.Name}' with input '{currentContext.Input}'", TraceSeverity.Medium, TraceCategory.Lookup);
                     }
                     else
                     {
-                        Logger.Log($"[{ClaimsProviderName}] Got no result from \"{tenant.Name}\" with input '{currentContext.Input}', search took {timer.ElapsedMilliseconds.ToString()} ms", TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Lookup);
+                        Logger.Log($"[{ClaimsProviderName}] Got no result from \"{tenant.Name}\" with input '{currentContext.Input}', search took {timer.ElapsedMilliseconds.ToString()} ms", TraceSeverity.Medium, TraceCategory.Lookup);
                     }
                     return tenantResults;
                 }
@@ -375,11 +375,11 @@ namespace Yvand.EntraClaimsProvider
 
             if (tenant.GraphService == null)
             {
-                Logger.Log($"[{ClaimsProviderName}] Cannot query Microsoft Entra ID tenant '{tenant.Name}' because it was not initialized", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Lookup);
+                Logger.Log($"[{ClaimsProviderName}] Cannot query Microsoft Entra ID tenant '{tenant.Name}' because it was not initialized", TraceSeverity.Unexpected, TraceCategory.Lookup);
                 return tenantResults;
             }
 
-            Logger.Log($"[{ClaimsProviderName}] Querying Microsoft Entra ID tenant '{tenant.Name}' for users and groups, with input '{currentContext.Input}'", TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Lookup);
+            Logger.Log($"[{ClaimsProviderName}] Querying Microsoft Entra ID tenant '{tenant.Name}' for users and groups, with input '{currentContext.Input}'", TraceSeverity.VerboseEx, TraceCategory.Lookup);
             object lockAddResultToCollection = new object();
             int timeout = this.Settings.Timeout;
             int maxRetry = currentContext.OperationType == OperationType.Validation ? 3 : 2;
@@ -518,7 +518,7 @@ namespace Yvand.EntraClaimsProvider
                         }
                         else
                         {
-                            Logger.Log($"[{ClaimsProviderName}] Query to tenant '{tenant.Name}' returned unexpected status '{usersRequestStatus}' for users request with filter \"{tenant.UserFilter}\"", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Lookup);
+                            Logger.Log($"[{ClaimsProviderName}] Query to tenant '{tenant.Name}' returned unexpected status '{usersRequestStatus}' for users request with filter \"{tenant.UserFilter}\"", TraceSeverity.Unexpected, TraceCategory.Lookup);
                         }
                     }
 
@@ -533,7 +533,7 @@ namespace Yvand.EntraClaimsProvider
                         }
                         else
                         {
-                            Logger.Log($"[{ClaimsProviderName}] Query to tenant '{tenant.Name}' returned unexpected status '{groupRequestStatus}' for groups request with filter \"{tenant.GroupFilter}\"", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Lookup);
+                            Logger.Log($"[{ClaimsProviderName}] Query to tenant '{tenant.Name}' returned unexpected status '{groupRequestStatus}' for groups request with filter \"{tenant.GroupFilter}\"", TraceSeverity.Unexpected, TraceCategory.Lookup);
                         }
                     }
 
@@ -565,11 +565,11 @@ namespace Yvand.EntraClaimsProvider
                                 }
                                 else if (allowedGroupMembersOfGroupResponseStatus == HttpStatusCode.NotFound)
                                 {
-                                    Logger.Log($"[{ClaimsProviderName}] Request inside the batch to get the members of a group on tenant \"{tenant.Name}\" returned nothing (the group was not found).", TraceSeverity.Verbose, EventSeverity.Information, TraceCategory.Lookup);
+                                    Logger.Log($"[{ClaimsProviderName}] Request inside the batch to get the members of a group on tenant \"{tenant.Name}\" returned nothing (the group was not found).", TraceSeverity.Verbose, TraceCategory.Lookup);
                                 }
                                 else
                                 {
-                                    Logger.Log($"[{ClaimsProviderName}] Request inside the batch to get the members of a group on tenant \"{tenant.Name}\" returned unexpected status '{allowedGroupMembersOfGroupResponseStatus}'", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Lookup);
+                                    Logger.Log($"[{ClaimsProviderName}] Request inside the batch to get the members of a group on tenant \"{tenant.Name}\" returned unexpected status '{allowedGroupMembersOfGroupResponseStatus}'", TraceSeverity.Unexpected, TraceCategory.Lookup);
                                 }
                             }
                         }
@@ -577,7 +577,7 @@ namespace Yvand.EntraClaimsProvider
                         lockToWriteInCachedDataWasTaken = false;
                     }
 
-                    Logger.Log($"[{ClaimsProviderName}] Query to tenant '{tenant.Name}' returned {(userCollectionResult?.Value == null ? 0 : userCollectionResult.Value.Count)} user(s) with filter \"{tenant.UserFilter}\" and {(groupCollectionResult?.Value == null ? 0 : groupCollectionResult.Value.Count)} group(s) with filter \"{tenant.GroupFilter}\"", TraceSeverity.VerboseEx, EventSeverity.Information, TraceCategory.Lookup);
+                    Logger.Log($"[{ClaimsProviderName}] Query to tenant '{tenant.Name}' returned {(userCollectionResult?.Value == null ? 0 : userCollectionResult.Value.Count)} user(s) with filter \"{tenant.UserFilter}\" and {(groupCollectionResult?.Value == null ? 0 : groupCollectionResult.Value.Count)} group(s) with filter \"{tenant.GroupFilter}\"", TraceSeverity.VerboseEx, TraceCategory.Lookup);
                     // Process users result
                     if (userCollectionResult?.Value != null)
                     {
@@ -664,7 +664,7 @@ namespace Yvand.EntraClaimsProvider
             }
             catch (OperationCanceledException)
             {
-                Logger.Log($"[{ClaimsProviderName}] Operation on Entra ID for tenant '{tenant.Name}' exceeded the timeout of {timeout} ms and was cancelled.", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Lookup);
+                Logger.Log($"[{ClaimsProviderName}] Operation on Entra ID for tenant '{tenant.Name}' exceeded the timeout of {timeout} ms and was cancelled.", TraceSeverity.Unexpected, TraceCategory.Lookup);
             }
             catch (AuthenticationFailedException ex)
             {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/GraphRequestsLogging.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/GraphRequestsLogging.cs
@@ -31,12 +31,12 @@ namespace Yvand.EntraClaimsProvider
             {
                 // httpRequest.Content is null if httpRequest is a GET (e.g. during augmentation)
                 string requestBody = httpRequest.Content == null ? string.Empty : await httpRequest.Content.ReadAsStringAsync().ConfigureAwait(false);
-                Logger.Log($"[{EntraCP.ClaimsProviderName}] Graph returned error {response.StatusCode} {response.ReasonPhrase} on request \"{httpRequest.RequestUri}\" with JSON payload \"{requestBody}\"", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.GraphRequests);
+                Logger.Log($"[{EntraCP.ClaimsProviderName}] Graph returned error {response.StatusCode} {response.ReasonPhrase} on request \"{httpRequest.RequestUri}\" with JSON payload \"{requestBody}\"", TraceSeverity.Unexpected, TraceCategory.GraphRequests);
             }
             else
             {
                 // Log in VerboseEx because as is, those messages aren't really useful
-                Logger.Log($"[{EntraCP.ClaimsProviderName}] Graph returned success {response.StatusCode} on request \"{httpRequest.RequestUri}\"", TraceSeverity.VerboseEx, EventSeverity.Verbose, TraceCategory.GraphRequests);
+                Logger.Log($"[{EntraCP.ClaimsProviderName}] Graph returned success {response.StatusCode} on request \"{httpRequest.RequestUri}\"", TraceSeverity.VerboseEx, TraceCategory.GraphRequests);
             }
             return response;
         }

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Logger.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Logger.cs
@@ -99,7 +99,7 @@ namespace Yvand.EntraClaimsProvider.Logging
                         });
         }
 
-        public static void Log(string message, TraceSeverity traceSeverity, EventSeverity eventSeverity, TraceCategory category)
+        public static void Log(string message, TraceSeverity traceSeverity, TraceCategory category)
         {
             try
             {

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Utils.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Utils.cs
@@ -35,9 +35,9 @@ namespace Yvand.EntraClaimsProvider
 
             if (lp != null && lp.Count() > 1)
             {
-                Logger.Log($"[{claimProviderName}] Cannot continue because '{claimProviderName}' is set with multiple SPTrustedIdentityTokenIssuer", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
+                Logger.Log($"[{claimProviderName}] Cannot continue because '{claimProviderName}' is set with multiple SPTrustedIdentityTokenIssuer", TraceSeverity.Unexpected, TraceCategory.Core);
             }
-            Logger.Log($"[{claimProviderName}] Cannot continue because '{claimProviderName}' is not set with any SPTrustedIdentityTokenIssuer.\r\nVisit {ClaimsProviderConstants.PUBLICSITEURL} for more information.", TraceSeverity.High, EventSeverity.Warning, TraceCategory.Core);
+            Logger.Log($"[{claimProviderName}] Cannot continue because '{claimProviderName}' is not set with any SPTrustedIdentityTokenIssuer.\r\nVisit {ClaimsProviderConstants.PUBLICSITEURL} for more information.", TraceSeverity.High, TraceCategory.Core);
             return null;
         }
 
@@ -221,30 +221,30 @@ namespace Yvand.EntraClaimsProvider
             return propertyValue == null ? String.Empty : propertyValue.ToString();
         }
 
-        public static EventLevel TraceSeverityToEventLevel(TraceSeverity level)
+        public static EventSeverity TraceSeverityToEventLevel(TraceSeverity level)
         {
-            EventLevel retLevel;
+            EventSeverity retLevel;
             switch (level)
             {
                 case TraceSeverity.Unexpected:
-                    retLevel = EventLevel.Critical;
+                    retLevel = EventSeverity.ErrorCritical;
                     break;
 
                 case TraceSeverity.High:
-                    retLevel = EventLevel.Error;
+                    retLevel = EventSeverity.Error;
                     break;
 
                 case TraceSeverity.Medium:
-                    retLevel = EventLevel.Warning;
+                    retLevel = EventSeverity.Warning;
                     break;
 
                 case TraceSeverity.VerboseEx:
                 case TraceSeverity.Verbose:
-                    retLevel = EventLevel.Informational;
+                    retLevel = EventSeverity.Verbose;
                     break;
 
                 default:
-                    retLevel = EventLevel.Warning;
+                    retLevel = EventSeverity.Error;
                     break;
             }
             return retLevel;
@@ -267,6 +267,8 @@ namespace Yvand.EntraClaimsProvider
                     retLevel = TraceSeverity.Medium;
                     break;
 
+                // Treat LogAlways based on https://learn.microsoft.com/en-us/dotnet/azure/sdk/logging#map-to-aspnet-core-logging
+                case EventLevel.LogAlways:
                 case EventLevel.Informational:
                 case EventLevel.Verbose:
                     // Set to VerboseEx instead of Verbose, because it generates very noisy messages

--- a/assembly-bindings.config
+++ b/assembly-bindings.config
@@ -2,7 +2,8 @@
 <!--
 This file contains the assembly bindings required to run EntraCP.
 
-Usage: On each SharePoint server, edit the file %systemroot%\Microsoft.NET\Framework64\v4.0.30319\Config\Machine.config 
+Usage: On each SharePoint server, edit the file:
+%systemroot%\Microsoft.NET\Framework64\v4.0.30319\Config\Machine.config
 and replace/update the default XML node <runtime /> with the whole XML node <runtime></runtime> below.
 
 The content of this file may change with each version of EntraCP, make sure to use the file corresponding to your version of EntraCP.
@@ -11,12 +12,8 @@ The content of this file may change with each version of EntraCP, make sure to u
 <runtime>
 <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
     <dependentAssembly>
-        <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral"/>
-        <bindingRedirect oldVersion="1.39.0.0" newVersion="1.40.0.0"/>
-    </dependentAssembly>
-    <dependentAssembly>
         <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="1.7.10.0-1.7.11.0" newVersion="1.9.1.0"/>
+        <bindingRedirect oldVersion="1.14.0.0" newVersion="1.15.2.0"/>
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
@@ -24,11 +21,11 @@ The content of this file may change with each version of EntraCP, make sure to u
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="6.35.0.0" newVersion="7.6.0.0"/>
+        <bindingRedirect oldVersion="6.35.0.0" newVersion="8.2.0.0"/>
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="4.0.1.2" newVersion="6.0.0.0"/>
+        <bindingRedirect oldVersion="6.0.0.0" newVersion="8.0.0.5"/>
     </dependentAssembly>
     <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
@@ -37,6 +34,10 @@ The content of this file may change with each version of EntraCP, make sure to u
     <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
         <bindingRedirect oldVersion="4.0.4.1" newVersion="6.0.0.0"/>
+    </dependentAssembly>
+	<dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="6.0.0.0" newVersion="8.0.0.0"/>
     </dependentAssembly>
 </assemblyBinding>
 </runtime>


### PR DESCRIPTION
## CHANGELOG

* Address security advisory CVE-2024-43485 (related to `System.Text.Json` 6.0.0) by bumping dependencies `Azure.Identity` and `Microsoft.Graph` to their latest version
* Fix a validation issue that impacted guest users, when the identifier property for guest users is the UserPrincipalName
* Fix the noisy logs of category "Azure Identity" due to new level `LogMsalAlways`, by recording logs with level `LogMsalAlways` as `VerboseEx`
* Remove the parameter EventSeverity in method Log(), as it can be deducted from parameter TraceSeverity